### PR TITLE
custom config cmd argument

### DIFF
--- a/ConfigFileLoader.cs
+++ b/ConfigFileLoader.cs
@@ -22,7 +22,7 @@ namespace WebOne
 		/// <param name="FileName">This configuration file name</param>
 		public static void LoadConfigFileContent(string[] Body, string FileName)
 		{
-			Console.WriteLine("Using configuration file {0}.", FileName);
+			// Console.WriteLine("Using configuration file {0}.", FileName);
 
 			for (int i = 0; i < Body.Length; i++)
 			{
@@ -70,7 +70,11 @@ namespace WebOne
 					if (Directory.Exists(@"C:\ProgramData\WebOne\")) DefaultConfigDir = @"C:\ProgramData\WebOne\";
 					break;
 				case PlatformID.Unix:
-					if (Directory.Exists(@"/etc/webone.conf.d/")) DefaultConfigDir = @"/etc/webone.conf.d/";
+					if (Directory.Exists(@"/etc/webone.conf.d/")) 
+                        DefaultConfigDir = @"/etc/webone.conf.d/";
+                    else if(Program.ArgsCustomConfigFile != "") {
+                        DefaultConfigDir = new FileInfo(Program.ArgsCustomConfigFile).DirectoryName + "/webone.conf.d/";
+                    }
 					break;
 					//may be rewritten to a separate function, see Program.GetConfigurationFileName() code
 			}
@@ -109,6 +113,7 @@ namespace WebOne
 		/// <param name="Path">Path of the configuration file.</param>
 		public static void LoadFile(string Path)
 		{
+            Console.WriteLine("Loading config: {0}", Path);
 			Path = ExpandMaskedVariables(Path);
 			if (!File.Exists(Path)) throw new FileNotFoundException();
 

--- a/Log.cs
+++ b/Log.cs
@@ -65,7 +65,7 @@ namespace WebOne
 						Environment.Version,
 						CommandLineArgs);
 					LogStreamWriter.WriteLine(StartMsg);
-					Console.WriteLine("Using event log file {0}.", LogFileName);
+					Console.WriteLine("Using event log file {0}", LogFileName);
 				}
 				catch (Exception ex)
 				{

--- a/webone.service
+++ b/webone.service
@@ -12,6 +12,9 @@ ExecStart=/usr/local/bin/webone --daemon
 ReadWriteDirectories=-/var/log/
 TimeoutStopSec=10
 Restart=on-failure
+RestartSec=5
+StartLimitInterval=5s
+StartLimitBurst=3
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Added new command line arguments /cfg; -cfg; -config arguments to be able to use a custom configuration paths, this works/tested only in Linux envs.
usage (ex. webone.service): 
```bash
...
ExecStart=/usr/local/bin/webone --daemon -cfg "/abs/path/to/webone.conf"
...
```