### PR TITLE
Autoinstall script / README update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,7 +221,7 @@ ClientBin/
 *.publishsettings
 orleans.codegen.cs
 
-# Including strong name files can present a security risk 
+# Including strong name files can present a security risk
 # (https://github.com/github/gitignore/pull/2483#issue-259490424)
 #*.snk
 
@@ -317,7 +317,7 @@ __pycache__/
 # OpenCover UI analysis results
 OpenCover/
 
-# Azure Stream Analytics local run output 
+# Azure Stream Analytics local run output
 ASALocalRun/
 
 # MSBuild Binary and Structured Log
@@ -326,7 +326,7 @@ ASALocalRun/
 # NVidia Nsight GPU debugger configuration file
 *.nvuser
 
-# MFractors (Xamarin productivity tool) working folder 
+# MFractors (Xamarin productivity tool) working folder
 .mfractor/
 
 # ATauenis's (WebOne main developer) garbage & test playground
@@ -338,3 +338,45 @@ ImageMagic/
 EXE/NotForGit/
 viewtube/
 WebFixes/
+
+# VSCode
+.vscode
+# !.vscode/settings.json
+# !.vscode/tasks.json
+# !.vscode/extensions.json
+# !.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+# MACOS General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+# ._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ Windows 7 (2008 R2) SP1+ / Linux / macOS and .NET 6.0 Runtime are required on se
 ## Install
 Manuals about how to set up a WebOne proxy on [Windows](https://github.com/atauenis/webone/wiki/Windows-installation) / [Linux](https://github.com/atauenis/webone/wiki/Linux-installation) / [macOS](https://github.com/atauenis/webone/wiki/MacOS-X-installation) servers are in the Wiki.
 
+### Automation scripts
+
+<p align="center">
+    <img src="https://skillicons.dev/icons?i=bash" />
+</p>
+
+Before to continue with building and installation, please check the [./autoinstall](./autoinstall/) directory, there maybe a faster and more convenient way of doing so.
+
+### Docker
+
+<p align="center">
+    <img src="https://skillicons.dev/icons?i=docker" />
+</p>
+
+Please follow the guidelines available at [docker-webone](https://github.com/way5/docker-webone).
+
 ## Run
 *	On Windows simply run `webone.exe`. Then open port 8080 in Windows Firewall settings.
 

--- a/autoinstall/webone.linux.sh
+++ b/autoinstall/webone.linux.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+clear
+echo -e "\n\033[32m               ______"
+echo -e "___      _________  /___________________ "
+echo -e "__ | /| / /  _ \\_  __ \\  __ \\_  __ \\  _ \\"
+echo -e "__ |/ |/ //  __/  /_/ / /_/ /  / / /  __/"
+echo -e "____/|__/ \\___//_.___/\\____//_/ /_/\\___/ "
+echo -e "----------------------------------------"
+echo -e "                    by Alexander Tauenis"
+echo -e "\033[0m"
+RD="$(cd $(dirname "$0") && pwd)"
+ARGS=$@
+RUNTM="linux-x64"
+MOD=0
+for n in $ARGS; do
+    if [ "$n" = "-i" ]; then
+        MOD=1
+    elif [ "$n" = "-u" ]; then
+        MOD=2
+    elif [ "$n" = "-arm" ]; then
+        RUNTM="linux-arm"
+    elif [ "$n" = "-arm64" ]; then
+        RUNTM="linux-arm64"
+    elif [ "$n" = "-musl" ]; then
+        RUNTM="linux-musl-x64"
+    elif [ "$n" = "-musl-arm" ]; then
+        RUNTM="linux-musl-arm64"
+    elif [ "$n" = "-android" ]; then
+        RUNTM="linux-bionic-arm64"
+    fi
+done
+## installing by default
+if [ $MOD -eq 1 ]; then
+    # check if the necessary utilities are installed and accessible
+    if ! command -v git &> /dev/null; then
+        echo -e "\033[1;31m(!) please, install git\033[0m\n"
+        exit 0
+    fi
+    # getting things ready
+    echo -e "\033[1;35m- PREPARE\033[0m\n"
+    if [ ! -d "$RD/webone" ]; then
+        git config --global http.version HTTP/1.1
+        git clone -b master --depth=1 --single-branch https://github.com/atauenis/webone.git && cd webone
+        git config pull.rebase false
+    else
+        cd "$RD/webone" && git pull
+    fi
+    cd $RD
+    echo -e "\n\033[1;35m- INSTALLATION\033[0m\n"
+    systemctl stop webone > /dev/null 2>&1
+    sleep 2
+    if [ -d "/usr/local/webone" ]; then
+        echo -e "- entering /usr/local/webone"
+        cd /usr/local/webone
+        rm -fR ./*  > /dev/null 2>&1
+    else
+        mkdir -p /usr/local/webone
+        chmod 0744 /usr/local/webone
+    fi
+    if [ -d "/etc/webone" ]; then
+        echo -e "- entering /etc/webone"
+        cd /etc/webone
+        rm ./webone.conf.old > /dev/null 2>&1
+        if [ -f "./webone.conf" ]; then
+            mv ./webone.conf ./webone.conf.old
+        fi
+    else
+        mkdir /etc/webone
+        chmod -R 755 /etc/webone
+    fi
+    if [ ! -f "/var/log/webone.log" ]; then
+        touch /var/log/webone.log
+        chmod 666 /var/log/webone.log
+    fi
+    echo -e "- entering $RD/webone"
+    cd $RD/webone
+    rm -rf ./webone-build > /dev/null 2>&1
+    # trying to install dotnet
+    if [ "$(which dotnet)" == "" ]; then
+        wget https://dot.net/v1/dotnet-install.sh
+        chmod +x ./dotnet-install.sh
+        ./dotnet-install.sh -c 7.0
+        rm dotnet-install.sh
+        ln -s /root/.dotnet/dotnet  /usr/local/bin
+        # optout on telemetry
+        set DOTNET_CLI_TELEMETRY_OPTOUT=1
+    fi
+    echo -e "\n-- Build\n"
+    dotnet build ./WebOne.csproj -r $RUNTM
+    echo -e "\n-- Make\n"
+    dotnet publish ./WebOne.csproj -c Release -r $RUNTM --self-contained -o ./webone-build
+    echo -e "\n-- Install\n"
+    cd ./webone-build
+    cp webone.conf /etc/webone
+    cp codepage.conf /etc/webone
+    # fixing: unable to create CA cert
+    chmod 755 /etc/webone
+    if [ ! -f "/etc/logrotate.d/webone" ]; then
+        mv webone.logrotate /etc/logrotate.d/webone
+    else
+        rm webone.logrotate > /dev/null 2>&1
+    fi
+    # creating service
+    if [ ! -f "/etc/systemd/system/webone.service" ]; then
+        echo -e -n  "[Unit]\n"\
+                    "Description=WebOne HTTP(S) Proxy Server\n"\
+                    "Documentation=https://github.com/atauenis/webone/wiki/\n"\
+                    "Requires=network-online.target\n"\
+                    "After=network-online.target\n\n"\
+                    "[Service]\n"\
+                    "Type=simple\n"\
+                    "DynamicUser=yes\n"\
+                    "Environment=\"HOME=/tmp/\"\n"\
+                    "ExecStart=/usr/local/bin/webone --daemon -cfg \"/etc/webone/webone.conf\"\n"\
+                    "ReadWriteDirectories=-/var/log/\n"\
+                    "TimeoutStopSec=10\n"\
+                    "Restart=on-failure\n"\
+                    "RestartSec=5\n"\
+                    "StartLimitInterval=5s\n"\
+                    "StartLimitBurst=3\n\n"\
+                    "[Install]\n"\
+                    "WantedBy=default.target\n" > /etc/systemd/system/webone.service
+    else
+        rm webone.service > /dev/null 2>&1
+    fi
+    # cleanup
+    rm README.md CONTRIBUTING.md  > /dev/null 2>&1
+    # moving program
+    cp -pr ./* /usr/local/webone/
+    # linking executables
+    if [ ! -f "/usr/local/bin/webone" ]; then
+        ln -s /usr/local/webone/webone /usr/local/bin/webone
+    fi
+    # grant access
+    chmod a+x /usr/local/webone /usr/local/webone/webone
+    echo -e "- initializing webone service"
+    systemctl daemon-reload
+    systemctl enable webone
+    systemctl start webone
+    sleep 2
+    systemctl status webone
+    echo -e "\n-- Cleanup\n"
+    cd ..
+    dotnet clean WebOne.csproj
+    rm -r ./webone-build > /dev/null 2>&1
+elif [ $MOD -eq 2 ]; then                   # MOD -ne 1
+    ## uninstall and cleanup
+    echo -e "\n\033[1;35m- UNINSTALL\033[0m\n"
+    systemctl stop webone
+    systemctl disable webone
+    systemctl daemon-reload
+    rm -f /etc/systemd/system/webone.service > /dev/null 2>&1
+    rm -fr /usr/local/webone > /dev/null 2>&1
+    rm -fr /etc/webone > /dev/null 2>&1
+else                                        # MOD
+    echo -e "\033[34mUsage:\n"
+    echo    "    [-i]        - install as a service"
+    echo -e "    [-u]        - completely uninstall webone, including configuration\n"
+    echo    "  Default building mode is for linux-x64 platforms which are most desktop distributions"
+    echo -e "  like CentOS, Debian, Fedora, Ubuntu, and derivatives.\n"
+    echo    "    [-arm]      - Linux distributions running on Arm like Raspbian on Raspberry Pi Model 2+"
+    echo    "    [-arm64]    - Linux distributions running on 64-bit Arm like Ubuntu Server"
+    echo    "                  64-bit on Raspberry Pi Model 3+"
+    echo    "    [-musl]     - Lightweight distributions using musl like Alpine Linux"
+    echo    "    [-musl-arm] - Used to build Docker images for 64-bit Arm v8 and minimalistic base images"
+    echo -e "    [-android]  - Distributions using Android's bionic libc, for example, Termux\n\033[0m"
+    exit 0
+fi                                          # MOD
+echo -e "\n\033[1;35m- ALL DONE\033[0m\n"
+exit 0


### PR DESCRIPTION
Since some people were wondering around the automatic build/install and the Docker setup I've added a small update just in order to save someone's time.  There is /autoinstall directory that (in theory) should contain automation scripts, which hopefully will be added more in future.
For now it allows to install WebOne onto machines with: Linux-ARM (x64), Linux (MUSL) x64 (ARMx64) (see: musl C runtime library), etc.. 
For more information run: 

```bash
./autoinstall/webone.linux.sh
```