### PR TITLE
Add redirects for WMP 7 and Windows 2000 CD Player metadata retrieval

### DIFF
--- a/webone.conf
+++ b/webone.conf
@@ -283,6 +283,10 @@ AddRedirect=http://musicmatch-ssl.xboxlive.com/cdinfo/GetMDRCD.aspx?$1
 [Edit:^http://.*?/https:/musicimage.xboxlive.com/(.*)]
 AddRedirect=http://musicimage.xboxlive.com/$1
 
+[Edit:^http://windowsmedia.com/redir/QueryTOC.asp\?.*?cd=(.*)]
+IgnoreUrl=WMPFriendly
+AddRedirect=http://cddb.retrobridge.org/tunes-cgi2/tunes/disc_info/203/cd=$1
+
 [Edit]
 OnUrl=^http://[a-z\.]*windowsmedia.com/
 OnUrl=^http://windowsmedia.com/
@@ -292,6 +296,10 @@ AddRedirect=http://web.archive.org/web/2002/%URL%
 ;OnUrl=^http://[a-z\.]*metaservices.microsoft.com
 ;AddRedirect=http://web.archive.org/web/2010/%URL%
 ;13.09.2022 - still works (WMP 10, 11) and not well archived
+
+; Windows CD Player
+[Edit:^http://www.tunes.com/(.*)]
+AddRedirect=http://cddb.retrobridge.org/$1
 
 ; Microsoft Windows Update
 [Edit:^http://www.update.microsoft.com/windowsupdate.*]

--- a/webone.conf
+++ b/webone.conf
@@ -298,8 +298,8 @@ AddRedirect=http://web.archive.org/web/2002/%URL%
 ;13.09.2022 - still works (WMP 10, 11) and not well archived
 
 ; Windows CD Player
-[Edit:^http://www.tunes.com/(.*)]
-AddRedirect=http://cddb.retrobridge.org/$1
+[Edit:^http://www.tunes.com/tunes-cgi2/tunes/disc_info/(.*)]
+AddRedirect=http://cddb.retrobridge.org/tunes-cgi2/tunes/disc_info/$1
 
 ; Microsoft Windows Update
 [Edit:^http://www.update.microsoft.com/windowsupdate.*]


### PR DESCRIPTION
I tinkered some more and came up with more redirects to restore metadata downloads on Windows Media Player 7.x as well as the Windows 2000 CD Player:

![image](https://github.com/user-attachments/assets/35783b99-d04f-4745-9784-0525a6545c4c)


Unfortunately Windows Media Player 8 will remain non functional as it is the only one that uses a proprietary XML format which is not documented or archived anywhere