### PR TITLE
Relative link to webone.css

### DIFF
--- a/html/InfoPage.htm
+++ b/html/InfoPage.htm
@@ -1,7 +1,7 @@
 ﻿<html>
 <title>%Title%</title>
 <meta charset="utf-8"/>
-<link href="http://%ServerName%/webone.css" rel="stylesheet" />
+<link href="webone.css" rel="stylesheet" />
 <body>
 <h1>%Header%</h1>
 %Content%


### PR DESCRIPTION
Changed variable-dependent link to webone.css to a relative link that is not variable dependent.

Discovered that loading time was long, when running WebOne under docker. This was because %ServerName% is apparently resolved to the docker container's own internal IP-address, which if course isn't visible to proxy clients (browsers)