### PR TITLE
Merge dev to master (v0.18.0)

### DIFF
--- a/ConfigFile.cs
+++ b/ConfigFile.cs
@@ -338,6 +338,11 @@ namespace WebOne
 		/// </summary>
 		public static Dictionary<string, string> NonHttpConnectRedirect = new();
 
+		/// <summary>
+		/// List of TLS/SSL/HTTPS servers for which any traffic edits must not be applied
+		/// </summary>
+		public static List<string> SslPassThrough = new();
+
 
 
 		// Hint: All parser-related stuff known from v0.2.0 - 0.10.7 has been rewritten and moved to ConfigFileLoader class.

--- a/ConfigFile.cs
+++ b/ConfigFile.cs
@@ -343,6 +343,11 @@ namespace WebOne
 		/// </summary>
 		public static List<string> ConnectPassThrough = new();
 
+		/// <summary>
+		/// List of non-HTTPS servers with TLS, which can be accessed via CONNECT method by non-SSL-capable clients
+		/// </summary>
+		public static Dictionary<string, string> NonHttpSslDecrypt = new();
+
 
 
 		// Hint: All parser-related stuff known from v0.2.0 - 0.10.7 has been rewritten and moved to ConfigFileLoader class.

--- a/ConfigFile.cs
+++ b/ConfigFile.cs
@@ -341,7 +341,7 @@ namespace WebOne
 		/// <summary>
 		/// List of TLS/SSL/HTTPS servers for which any traffic edits must not be applied
 		/// </summary>
-		public static List<string> SslPassThrough = new();
+		public static List<string> ConnectPassThrough = new();
 
 
 

--- a/ConfigFileLoader.cs
+++ b/ConfigFileLoader.cs
@@ -594,6 +594,23 @@ namespace WebOne
 							}
 						}
 						break;
+					case "NonHttpSslDecrypt":
+						foreach (ConfigFileOption Line in Section.Options)
+						{
+							if (Line.HaveKeyValue
+							&& Line.Value.Split(':').Length == 2
+							&& !string.IsNullOrWhiteSpace(Line.Value.Split(':')[0])
+							&& int.TryParse(Line.Value.Split(':')[1], out int devnull))
+							{
+								ConfigFile.NonHttpSslDecrypt.Add(Line.Key, Line.Value);
+							}
+							else
+							{
+								Log.WriteLine(true, false, "Warning: Incorrect non-HTTPS with SSL/TLS decryption connection redirect rule at {0}.", Line.Location);
+								continue;
+							}
+						}
+						break;
 					case "ConnectPassThrough":
 						foreach (ConfigFileOption Line in Section.Options)
 						{

--- a/ConfigFileLoader.cs
+++ b/ConfigFileLoader.cs
@@ -594,10 +594,10 @@ namespace WebOne
 							}
 						}
 						break;
-					case "SslPassThrough":
+					case "ConnectPassThrough":
 						foreach (ConfigFileOption Line in Section.Options)
 						{
-							ConfigFile.SslPassThrough.Add(Line.RawString.ToLowerInvariant());
+							ConfigFile.ConnectPassThrough.Add(Line.RawString.ToLowerInvariant());
 						}
 						break;
 					case "Http10Only":

--- a/ConfigFileLoader.cs
+++ b/ConfigFileLoader.cs
@@ -594,6 +594,12 @@ namespace WebOne
 							}
 						}
 						break;
+					case "SslPassThrough":
+						foreach (ConfigFileOption Line in Section.Options)
+						{
+							ConfigFile.SslPassThrough.Add(Line.RawString.ToLowerInvariant());
+						}
+						break;
 					case "Http10Only":
 						foreach (ConfigFileOption Line in Section.Options)
 						{

--- a/HttpSecureNonHttpDecryptServer.cs
+++ b/HttpSecureNonHttpDecryptServer.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.IO;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+
+namespace WebOne
+{
+	/// <summary>
+	/// CONNECT Proxy Server for all protocols tunneling with full SSL decrypting
+	/// </summary>
+	class HttpSecureNonHttpDecryptServer
+	{
+		Stream ClientStream;
+		Stream RemoteStream;
+		HttpRequest RequestReal;
+		HttpResponse ResponseReal;
+		LogWriter Logger;
+
+		string HostName;
+		int PortNo;
+
+		/// <summary>
+		/// Start CONNECT proxy server emulation for already established NetworkStream.
+		/// </summary>
+		public HttpSecureNonHttpDecryptServer(HttpRequest Request, HttpResponse Response, string TargetServer, LogWriter Logger)
+		{
+			RequestReal = Request;
+			ResponseReal = Response;
+			ClientStream = Request.InputStream;
+			this.Logger = Logger;
+
+			HostName = TargetServer.Substring(0, TargetServer.IndexOf(":"));
+			PortNo = int.Parse(TargetServer.Substring(TargetServer.IndexOf(":") + 1));
+		}
+
+		/// <summary>
+		/// Accept an incoming "connection" by establishing tunnel &amp; start data exchange.
+		/// </summary>
+		public void Accept()
+		{
+			// Answer that this proxy supports CONNECT method
+			ResponseReal.ProtocolVersion = new Version(1, 1);
+			ResponseReal.StatusCode = 200;
+			ResponseReal.StatusMessage = " Connection established";
+			ResponseReal.SendHeaders(); //"HTTP/1.1 200 Connection established"
+			Logger.WriteLine(">Decrypt: {0}:{1}", HostName, PortNo);
+
+			// Establish tunnel
+			TcpClient TunnelToRemote = new();
+			try
+			{
+				TunnelToRemote.Connect(HostName, PortNo);
+				Logger.WriteLine(" D tunnel connected.");
+
+				RemoteStream = new SslStream(TunnelToRemote.GetStream(), true);
+				((SslStream)RemoteStream).AuthenticateAsClient(HostName);
+				Logger.WriteLine(" D tunnel established.");
+			}
+			catch (Exception ex)
+			{
+				//An error occured, try to return nice error message, some clients like KVIrc will display it
+				Logger.WriteLine(" D connection failed: {0}.", ex.Message);
+				try { new StreamWriter(ClientStream).WriteLine("The proxy server is unable to connect with decryption: " + ex.Message); }
+				catch { };
+				ClientStream.Close();
+				return;
+			}
+
+			// Do routing
+			bool TunnelAlive = true;
+			try
+			{
+				BinaryReader BRclient = new(ClientStream);
+				BinaryWriter BWclient = new(ClientStream);
+				BinaryReader BRremote = new(RemoteStream);
+				BinaryWriter BWremote = new(RemoteStream);
+
+				new Task(() =>
+				{
+					try
+					{
+						while (true)
+						{
+							BWremote.Write(BRclient.ReadByte());
+						}
+					}
+					catch { TunnelAlive = false; }
+				}).Start();
+
+				new Task(() =>
+				{
+					try
+					{
+						while (true)
+						{
+							BWclient.Write(BRremote.ReadByte());
+						}
+					}
+					catch { TunnelAlive = false; }
+				}).Start();
+			}
+			catch (Exception ex)
+			{
+				Logger.WriteLine(" D tunnel error: {0}. Closing.", ex.ToString());
+				TunnelAlive = false;
+			};
+
+			// Wait while connecion is alive
+			while (TunnelAlive)
+			{
+				System.Threading.Thread.Sleep(1000);
+				TunnelAlive = (ClientStream as NetworkStream).Socket.Connected;
+			};
+
+			// All done, close
+			if (TunnelToRemote.Connected)
+			{
+				TunnelToRemote.Close();
+				Logger.WriteLine(" D connection to {0} closed.", RequestReal.RawUrl);
+			}
+			else Logger.WriteLine(" D connection to {0} lost.", RequestReal.RawUrl);
+			ClientStream.Close();
+
+			return;
+
+		}
+	}
+}

--- a/HttpSecureNonHttpDecryptServer.cs
+++ b/HttpSecureNonHttpDecryptServer.cs
@@ -40,12 +40,29 @@ namespace WebOne
 		/// </summary>
 		public void Accept()
 		{
-			// Answer that this proxy supports CONNECT method
-			ResponseReal.ProtocolVersion = new Version(1, 1);
-			ResponseReal.StatusCode = 200;
-			ResponseReal.StatusMessage = " Connection established";
-			ResponseReal.SendHeaders(); //"HTTP/1.1 200 Connection established"
-			Logger.WriteLine(">Decrypt: {0}:{1}", HostName, PortNo);
+			if (ConfigFile.AllowNonHttpsCONNECT)
+			{
+				// Answer that this proxy supports CONNECT method
+				ResponseReal.ProtocolVersion = new Version(1, 1);
+				ResponseReal.StatusCode = 200;
+				ResponseReal.StatusMessage = " Connection established";
+				ResponseReal.SendHeaders(); //"HTTP/1.1 200 Connection established"
+				Logger.WriteLine(">Decrypt: {0}:{1}", HostName, PortNo);
+			}
+			else
+			{
+				// Reject connection request
+				string OnlyHTTPS = "This proxy is performing only HTTP and HTTPS tunneling.";
+				ResponseReal.ProtocolVersion = new Version(1, 1);
+				ResponseReal.StatusCode = 502;
+				ResponseReal.ContentType = "text/plain";
+				ResponseReal.ContentLength64 = OnlyHTTPS.Length;
+				ResponseReal.SendHeaders();
+				ResponseReal.OutputStream.Write(System.Text.Encoding.Default.GetBytes(OnlyHTTPS), 0, OnlyHTTPS.Length);
+				ResponseReal.Close();
+				Logger.WriteLine("<Not a HTTPS CONNECT, goodbye.");
+				return;
+			}
 
 			// Establish tunnel
 			TcpClient TunnelToRemote = new();

--- a/HttpSecurePassthroughServer.cs
+++ b/HttpSecurePassthroughServer.cs
@@ -3,11 +3,11 @@ using System.IO;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 
-/// <summary>
-/// CONNECT Proxy Server for all protocols tunneling without SSL certificate spoof
-/// </summary>
 namespace WebOne
 {
+	/// <summary>
+	/// CONNECT Proxy Server for all protocols tunneling without SSL certificate spoof
+	/// </summary>
 	class HttpSecurePassthroughServer
 	{
 		Stream ClientStream;
@@ -38,6 +38,22 @@ namespace WebOne
 		/// </summary>
 		public void Accept()
 		{
+			// Check for unwanted usage
+			if (PortNo != 443 && !ConfigFile.AllowNonHttpsCONNECT)
+			{
+				// Reject connection request
+				string OnlyHTTPS = "This proxy is performing only HTTP and HTTPS tunneling.";
+				ResponseReal.ProtocolVersion = new Version(1, 1);
+				ResponseReal.StatusCode = 502;
+				ResponseReal.ContentType = "text/plain";
+				ResponseReal.ContentLength64 = OnlyHTTPS.Length;
+				ResponseReal.SendHeaders();
+				ResponseReal.OutputStream.Write(System.Text.Encoding.Default.GetBytes(OnlyHTTPS), 0, OnlyHTTPS.Length);
+				ResponseReal.Close();
+				Logger.WriteLine("<Not a HTTPS CONNECT, goodbye.");
+				return;
+			}
+
 			// Answer that this proxy supports CONNECT method
 			ResponseReal.ProtocolVersion = new Version(1, 1);
 			ResponseReal.StatusCode = 200;

--- a/HttpSecurePassthroughServer.cs
+++ b/HttpSecurePassthroughServer.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+/// <summary>
+/// CONNECT Proxy Server for all protocols tunneling without SSL certificate spoof
+/// </summary>
+namespace WebOne
+{
+	class HttpSecurePassthroughServer
+	{
+		Stream ClientStream;
+		Stream RemoteStream;
+		HttpRequest RequestReal;
+		HttpResponse ResponseReal;
+		LogWriter Logger;
+
+		string HostName;
+		int PortNo;
+
+		/// <summary>
+		/// Start CONNECT proxy server emulation for already established NetworkStream.
+		/// </summary>
+		public HttpSecurePassthroughServer(HttpRequest Request, HttpResponse Response, LogWriter Logger)
+		{
+			RequestReal = Request;
+			ResponseReal = Response;
+			ClientStream = Request.InputStream;
+			this.Logger = Logger;
+
+			HostName = RequestReal.RawUrl.Substring(0, RequestReal.RawUrl.IndexOf(":"));
+			PortNo = int.Parse(RequestReal.RawUrl.Substring(RequestReal.RawUrl.IndexOf(":") + 1));
+		}
+
+		/// <summary>
+		/// Accept an incoming "connection" by establishing tunnel &amp; start data exchange.
+		/// </summary>
+		public void Accept()
+		{
+			// Answer that this proxy supports CONNECT method
+			ResponseReal.ProtocolVersion = new Version(1, 1);
+			ResponseReal.StatusCode = 200;
+			ResponseReal.StatusMessage = " Connection established";
+			ResponseReal.SendHeaders(); //"HTTP/1.1 200 Connection established"
+			Logger.WriteLine(">Passthrough: {0}", RequestReal.RawUrl);
+
+			// Establish tunnel
+			TcpClient TunnelToRemote = new();
+			try
+			{
+				TunnelToRemote.Connect(HostName, PortNo);
+
+				RemoteStream = TunnelToRemote.GetStream();
+				Logger.WriteLine(" PT tunnel established.", RequestReal.RawUrl);
+			}
+			catch (Exception ex)
+			{
+				//An error occured, try to return nice error message, some clients like KVIrc will display it
+				Logger.WriteLine(" PT Connection failed: {0}.", ex.Message);
+				try { new StreamWriter(ClientStream).WriteLine("The proxy server is unable to connect pass-though: " + ex.Message); }
+				catch { };
+				ClientStream.Close();
+				return;
+			}
+
+			// Do routing
+			bool TunnelAlive = true;
+			try
+			{
+				BinaryReader BRclient = new(ClientStream);
+				BinaryWriter BWclient = new(ClientStream);
+				BinaryReader BRremote = new(RemoteStream);
+				BinaryWriter BWremote = new(RemoteStream);
+
+				new Task(() =>
+				{
+					try
+					{
+						while (true)
+						{
+							BWremote.Write(BRclient.ReadByte());
+						}
+					}
+					catch { TunnelAlive = false; }
+				}).Start();
+
+				new Task(() =>
+				{
+					try
+					{
+						while (true)
+						{
+							BWclient.Write(BRremote.ReadByte());
+						}
+					}
+					catch { TunnelAlive = false; }
+				}).Start();
+			}
+			catch (Exception ex)
+			{
+				Logger.WriteLine(" PT tunnel error: {0}. Closing.", ex.ToString());
+				TunnelAlive = false;
+			};
+
+			// Wait while connecion is alive
+			while (TunnelAlive)
+			{
+				System.Threading.Thread.Sleep(1000);
+				TunnelAlive = (ClientStream as NetworkStream).Socket.Connected;
+			};
+
+			// All done, close
+			if (TunnelToRemote.Connected)
+			{
+				TunnelToRemote.Close();
+				Logger.WriteLine(" PT connection to {0} closed.", RequestReal.RawUrl);
+			}
+			else Logger.WriteLine(" PT connection to {0} lost.", RequestReal.RawUrl);
+			ClientStream.Close();
+
+			return;
+
+		}
+	}
+}

--- a/HttpSecureServer.cs
+++ b/HttpSecureServer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Net.Security;
-using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using static WebOne.Program;
 
@@ -54,9 +53,12 @@ namespace WebOne
 				string Html =
 				"<HTML><HEAD>" +
 				"<TITLE>WebOne: SSL is not supported</TITLE></HEAD>" +
-				"<BODY><P><BIG>Sorry, Secure traffic transfer is disabled on proxy server.</BIG></P>" +
-				"<P>Set <B>SslEnable</B> to <B>yes</B> in configuration file to allow work with HTTPS &amp; SSL. Also make sure that CA files are accessible.</P>"+
-				"<P>Or set the proxy usage only for HTTP protocol in your Web-browser settings.</P>" + GetInfoString() + "</BODY></HTML>";
+				"<BODY><P>Incoming HTTPS connections support is disabled on this server.</P>" + GetInfoString() + "</BODY></HTML>";
+
+				if (File.Exists(ConfigFile.ContentDirectory + "/Err-SslDisabled.htm"))
+				{
+					Html = File.ReadAllText(ConfigFile.ContentDirectory + "/Err-SslDisabled.htm");
+				}
 
 				byte[] Buffer = (System.Text.Encoding.Default).GetBytes(Html);
 				try
@@ -96,7 +98,7 @@ namespace WebOne
 
 				ClientStreamTunnel = new SslStream(ClientStreamReal, false);
 				ClientStreamTunnel.AuthenticateAsServer(ClientStreamTunnelOptions);
-				
+
 
 				/* Result:
 				 * Ssl2 with Rc4 128-bit, Md5 128-bit

--- a/HttpTransit.cs
+++ b/HttpTransit.cs
@@ -149,6 +149,13 @@ namespace WebOne
 							return;
 						}
 
+						//check for SSL full decrypt mode
+						if (ConfigFile.NonHttpSslDecrypt.ContainsKey(ClientRequest.RawUrl))
+						{
+							new HttpSecureNonHttpDecryptServer(ClientRequest, ClientResponse, ConfigFile.NonHttpSslDecrypt[ClientRequest.RawUrl], Log).Accept();
+							return;
+						}
+
 						//work as HTTPS proxy
 						if (ClientRequest.RawUrl.EndsWith(":443"))
 						{

--- a/HttpTransit.cs
+++ b/HttpTransit.cs
@@ -141,6 +141,14 @@ namespace WebOne
 							SendError(400, "Invalid request. Correct format is <pre>CONNECT example.com:443 HTTP/1.1</pre>");
 							return;
 						}
+
+						//check for pass-through mode
+						if (CheckStringRegExp(ConfigFile.SslPassThrough.ToArray(), ClientRequest.RawUrl))
+						{
+							new HttpSecurePassthroughServer(ClientRequest, ClientResponse, Log).Accept();
+							return;
+						}
+
 						//work as HTTPS proxy
 						if (ClientRequest.RawUrl.EndsWith(":443"))
 						{

--- a/HttpTransit.cs
+++ b/HttpTransit.cs
@@ -143,7 +143,7 @@ namespace WebOne
 						}
 
 						//check for pass-through mode
-						if (CheckStringRegExp(ConfigFile.SslPassThrough.ToArray(), ClientRequest.RawUrl))
+						if (CheckStringRegExp(ConfigFile.ConnectPassThrough.ToArray(), ClientRequest.RawUrl))
 						{
 							new HttpSecurePassthroughServer(ClientRequest, ClientResponse, Log).Accept();
 							return;

--- a/Program.cs
+++ b/Program.cs
@@ -63,7 +63,7 @@ namespace WebOne
 			Assembly.GetExecutingAssembly().GetName().Version.Major + "." +
 			Assembly.GetExecutingAssembly().GetName().Version.Minor + "." +
 			Assembly.GetExecutingAssembly().GetName().Version.Build
-			//+ "-pre"
+			+ "-pre"
 			);
 			Variables.Add("WOSystem", RuntimeInformation.OSDescription);
 

--- a/Program.cs
+++ b/Program.cs
@@ -63,7 +63,7 @@ namespace WebOne
 			Assembly.GetExecutingAssembly().GetName().Version.Major + "." +
 			Assembly.GetExecutingAssembly().GetName().Version.Minor + "." +
 			Assembly.GetExecutingAssembly().GetName().Version.Build
-			+ "-pre"
+			//+ "-pre"
 			);
 			Variables.Add("WOSystem", RuntimeInformation.OSDescription);
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The program's settings are in the __webone.conf__ file (but any other file name 
 See **[WebOne wiki](https://github.com/atauenis/webone/wiki)** for complete list of features and full documentation.
 
 ## Server prerequisites
-Windows 7 (2008 R2) SP1+ / Linux / macOS and .NET 6.0 Runtime are required on server PC. See [.NET 6.0 System Requirements](https://github.com/dotnet/core/blob/main/release-notes/6.0/supported-os.md).
+Windows 8+ (or Windows Server 2012+) / Linux / macOS and .NET 8.0 Runtime are required on server PC. See [.NET 8.0 System Requirements](https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md).
 
 ## Image and video converting
 * Picture format converting is performing via `convert` utility from ImageMagick (bundled with WebOne).
@@ -55,7 +55,7 @@ The server can be started even on public hosts. But don't forget to enable passw
 ## Build
 Latest source code can be always found in the __master__ (![](https://img.shields.io/github/v/tag/atauenis/webone?include_prereleases&label=)) and the __dev__ branches of the [Git repository](https://github.com/atauenis/webone).
 
-The program is built using Microsoft .NET 6.0 SDK and [dotnet-packaging](https://github.com/qmfrederik/dotnet-packaging/) add-on. With them the building is easy on all platforms: use `dotnet publish` & `dotnet deb || dotnet rpm || dotnet zip` tools.
+The program is built using Microsoft .NET 8.0 SDK and [dotnet-packaging](https://github.com/qmfrederik/dotnet-packaging/) add-on. With them the building is easy on all platforms: use `dotnet publish` & `dotnet deb || dotnet rpm || dotnet zip` tools.
 
 Windows developers can utilize `build.bat` script for cross-platform building. And there is similar `build.sh` script for Linux and macOS environments.
 
@@ -84,7 +84,7 @@ __WebOne__ - прокси-сервер HTTP (HTTPS), позволяющий от
 * Скачивание и конвертация видео с YouTube для воспроизведения на старых ПК в браузере.
 * Клиент FTP для обращения к таким серверам через браузер.
 
-Этот прокси-сервер необходимо запускать на любом современном ПК с Microsoft .NET 6.0 Runtime, IP адрес которого указывается в настройках устаревшего веб-обозревателя. Порт по умолчанию 8080, тип прокси HTTP 1.0. Доступен файл автоматической настройки: http://proxyhost:port/auto.pac .
+Этот прокси-сервер необходимо запускать на любом современном ПК с Microsoft .NET 8.0 Runtime, IP адрес которого указывается в настройках устаревшего веб-обозревателя. Порт по умолчанию 8080, тип прокси HTTP 1.0. Доступен файл автоматической настройки: http://proxyhost:port/auto.pac .
 
 Настройки прокси-сервера хранятся в файле __webone.conf__ или любом другом в одном из следующих мест:
 

--- a/WebOne.csproj
+++ b/WebOne.csproj
@@ -3,10 +3,10 @@
 	<PropertyGroup>
 		<AssemblyName>webone</AssemblyName>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Authors>Alexander Tauenis</Authors>
-		<Version>0.17.6</Version>
-		<VersionSuffix></VersionSuffix> <!--<VersionSuffix>-pre</VersionSuffix>-->
+		<Version>0.18.0</Version>
+		<VersionSuffix>-pre</VersionSuffix> <!--<VersionSuffix>-pre</VersionSuffix>-->
 		<PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
 		<Company>World</Company>
 		<Product>WebOne HTTP Proxy Server</Product>
@@ -72,9 +72,9 @@
 
 	<ItemGroup Condition="$(SelfContained)==false">
 		<DebDotNetDependencies Remove="@(DebDotNetDependencies)" />
-		<DebDotNetDependencies Include="dotnet-runtime-6.0" />
+		<DebDotNetDependencies Include="dotnet-runtime-8.0" />
 		<RpmDotNetDependency Remove="@(RpmDotNetDependency)" />
-		<RpmDotNetDependency Include="dotnet-runtime-6.0" />
+		<RpmDotNetDependency Include="dotnet-runtime-8.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/WebOne.csproj
+++ b/WebOne.csproj
@@ -78,7 +78,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<DebDependency Include="imagemagick-6.q16" />
+		<DebDependency Include="imagemagick-7.q16 | imagemagick-6.q16" />
 		<DebRecommends Include="ffmpeg" />
 		<DebRecommends Include="yt-dlp" />
 	</ItemGroup>

--- a/WebOne.csproj
+++ b/WebOne.csproj
@@ -6,7 +6,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<Authors>Alexander Tauenis</Authors>
 		<Version>0.18.0</Version>
-		<VersionSuffix>-pre</VersionSuffix> <!--<VersionSuffix>-pre</VersionSuffix>-->
+		<VersionSuffix></VersionSuffix> <!--<VersionSuffix>-pre</VersionSuffix>-->
 		<PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
 		<Company>World</Company>
 		<Product>WebOne HTTP Proxy Server</Product>

--- a/Win32-full/yt-dlp.txt
+++ b/Win32-full/yt-dlp.txt
@@ -1,7 +1,8 @@
-2025.09.05
+2025.10.22
 Usage: yt-dlp [OPTIONS] URL [URL...]
 
 Options:
+
   General Options:
     -h, --help                      Print this help text and exit
     --version                       Print program version and exit
@@ -22,7 +23,6 @@ Options:
                                     playlist (default)
     --abort-on-error                Abort downloading of further videos if an
                                     error occurs (Alias: --no-ignore-errors)
-    --dump-user-agent               Display the current user-agent and exit
     --list-extractors               List all supported extractors and exit
     --extractor-descriptions        Output descriptions of all supported
                                     extractors and exit
@@ -276,8 +276,6 @@ Options:
                                     --playlist-random and --playlist-reverse
     --no-lazy-playlist              Process videos in the playlist only after
                                     the entire playlist is parsed (default)
-    --xattr-set-filesize            Set file xattribute ytdl.filesize with
-                                    expected file size
     --hls-use-mpegts                Use the mpegts container for HLS videos;
                                     allowing some players to play the video
                                     while downloading, and reducing the chance
@@ -301,9 +299,9 @@ Options:
                                     use (optionally) prefixed by the protocols
                                     (http, ftp, m3u8, dash, rstp, rtmp, mms) to
                                     use it for. Currently supports native,
-                                    aria2c, avconv, axel, curl, ffmpeg, httpie,
-                                    wget. You can use this option multiple times
-                                    to set different downloaders for different
+                                    aria2c, axel, curl, ffmpeg, httpie, wget.
+                                    You can use this option multiple times to
+                                    set different downloaders for different
                                     protocols. E.g. --downloader aria2c
                                     --downloader "dash,m3u8:native" will use
                                     aria2c for http/ftp downloads, and the

--- a/build.bat
+++ b/build.bat
@@ -1,4 +1,4 @@
-@echo WebOne build script	28.11.2023
+@echo WebOne build script	30.10.2025
 @echo.
 
 @echo Clean up directories:
@@ -28,7 +28,7 @@ dotnet publish -c Release -r osx-x64 -t:CreateZip,Clean
 dotnet publish -c Release -r osx-arm64 -t:CreateZip,Clean
 dotnet publish -c Release -r win-x86 -t:CreateZip,Clean
 dotnet publish -c ReleaseSC -r win-x86 -t:CreateZip,Clean
-dotnet publish -c Release -r win-arm -t:CreateZip,Clean
+dotnet publish -c Release -r win-arm64 -t:CreateZip,Clean
 dotnet publish -c Release -r win-x64 -t:CreateZip,Clean
 @rem Win32 build must be last because else VS debugging will be broken.
 @echo.
@@ -57,6 +57,6 @@ dotnet deb install
 
 :NoNetSDK
 @echo ERROR:
-@echo You need to have Microsoft .NET SDK 6 or Microsoft Visual Studio 2022+.
-@echo Download it here: https://dotnet.microsoft.com/en-us/download/dotnet/6.0
-@echo          or here: https://visualstudio.microsoft.com/ru/vs/community/
+@echo You need to have Microsoft .NET SDK 8 or Microsoft Visual Studio 2022+.
+@echo Download it here: https://dotnet.microsoft.com/en-us/download/dotnet/8.0
+@echo          or here: https://visualstudio.microsoft.com/en/vs/community/

--- a/build.sh
+++ b/build.sh
@@ -7,5 +7,5 @@ dotnet publish -c Release -r osx-x64 -t:CreateZip,Clean
 dotnet publish -c Release -r osx-arm64 -t:CreateZip,Clean
 dotnet publish -c Release -r win-x86 -t:CreateZip,Clean
 dotnet publish -c ReleaseSC -r win-x86 -t:CreateZip,Clean
-dotnet publish -c Release -r win-arm -t:CreateZip,Clean
+dotnet publish -c Release -r win-arm64 -t:CreateZip,Clean
 dotnet publish -c Release -r win-x64 -t:CreateZip,Clean

--- a/html/Err-SslDisabled.htm
+++ b/html/Err-SslDisabled.htm
@@ -1,0 +1,11 @@
+﻿<html>
+<title>HTTPS Is Not Supported</title>
+<meta charset="utf-8"/>
+<link href="http://%ServerName%/webone.css" rel="stylesheet" />
+<body>
+<P><BIG>Sorry, Secure traffic transfer is disabled on proxy server.</BIG></P>
+<P>Set <B>SslEnable</B> to <B>yes</B> in configuration file to allow work with HTTPS &amp; SSL. Also make sure that CA files are accessible.</P>
+<P>Or set the proxy usage only for HTTP protocol in your Web-browser settings. Any HTTPS websites can be accessed via plain HTTP protocol via the proxy.</P>
+<hr>WebOne Proxy Server %WOVer% <br>on %WOSystem%
+</body>
+</html>

--- a/webone.conf
+++ b/webone.conf
@@ -1231,7 +1231,7 @@ ul
 ; Redirect rules for non-HTTP connections
 ;login.icq.com:5190=login.oscar.someserver.com:5190
 
-[SslPassThrough]
+[ConnectPassThrough]
 ; List of HTTPS or non-HTTPS servers for which any traffic edits must not be applied
 nppl.c.app.nintendowifi.net:443
 l-npns.app.nintendo.net:443

--- a/webone.conf
+++ b/webone.conf
@@ -1229,7 +1229,14 @@ ul
 
 [NonHttpConnectRedirect]
 ; Redirect rules for non-HTTP connections
-;login.icq.com:5190=login.oscar.nina.chat:5190
+;login.icq.com:5190=login.oscar.someserver.com:5190
+
+[SslPassThrough]
+; List of HTTPS or non-HTTPS servers for which any traffic edits must not be applied
+nppl.c.app.nintendowifi.net:443
+l-npns.app.nintendo.net:443
+cbvc.cdn.nintendo.net:443
+nasc.nintendowifi.net:443
 
 
 [Include:%WOConfigDir%/*.conf]

--- a/webone.conf
+++ b/webone.conf
@@ -1226,6 +1226,9 @@ ul
 :6696
 :6697
 
+[NonHttpSslDecrypt]
+; List of non-HTTPS with SSL/TLS, which need to be available without SSL/TLS encryption
+irc.libera.chat:6667=irc.libera.chat:6697
 
 [NonHttpConnectRedirect]
 ; Redirect rules for non-HTTP connections


### PR DESCRIPTION
* **Now using .NET 8.0 Runtime instead of .NET 6.0.**
* Windows 8+ (Server 2012+), Ubuntu 20.04+, Debian 10+, Fedora 37+, macOS 12+ are now minimum supported versions to run WebOne. Windows 7 (2008 R2) is no longer supported, however WebOne still may be run on it with some issues.
* Added Windows 11 ARM64 support. Also added Ubuntu 25.04, 25.10, Debian 13 support (amd64, armhf, arm64, armv6).
* Added HTTPS pass-through mode for particular domains, fixing Nintendo 3DS browser startup (bug #183). Use `[ConnectPassThrough]` section in configuration file to specify domains where the mode should be used.
* Added ability to decrypt TLS-based protocols like secure-IRC to plain-text versions of them, say, plain-IRC. Use `[NonHttpSslDecrypt]` section in configuration file to specify domains where the mode should be used. Now you can use old clients like mIRC 6.x to connect to such servers when they're listed in configuration. By default Libera.Chat (which is an secure-IRC-only server) is added to the list.
* (Windows builds) Updated bundled Yt-Dlp version.