### PR TITLE
add --web-snapshot-viewer mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,31 @@ ImageMagic/
 EXE/NotForGit/
 viewtube/
 WebFixes/
+
+## MacOS gitignore ##
+
+# General
+.DS_Store
+__MACOSX/
+.AppleDouble
+.LSOverride
+Icon[]
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/HttpTransit.cs
+++ b/HttpTransit.cs
@@ -188,6 +188,13 @@ namespace WebOne
 				string RefererUri = ClientRequest.Headers["Referer"];
 				if (RefererUri == "") RefererUri = null;
 
+				//check for web snapshot viewer mode
+				if (Program.SnapshotViewerMode)
+				{
+					new WebOne.SnapshotViewer.WebSnapshotViewer(ClientRequest, ClientResponse, Log).Handle(RequestURL);
+					return;
+				}
+
 				//check for blacklisted URL
 				if (CheckString(RequestURL.ToString(), ConfigFile.UrlBlackList))
 				{

--- a/Program.cs
+++ b/Program.cs
@@ -33,6 +33,11 @@ namespace WebOne
 
 		public static string Protocols = "HTTP 1.1";
 		public static bool DaemonMode = false;
+		public static bool SnapshotViewerMode = false;
+		public static bool SnapshotViewerHeaded = false;
+		public static int JpegQuality = 85;
+		public static int StripHeight = 100;
+		public static int MinThreads = 1000;
 		static bool ShutdownInitiated = false;
 		static bool RebuildCA = false;
 
@@ -253,6 +258,13 @@ namespace WebOne
 				return;
 			}
 
+			//allow up to MinThreads concurrent requests without thread pool starvation
+			System.Threading.ThreadPool.SetMinThreads(MinThreads, MinThreads);
+
+			//pre-warm the browser driver so the first snapshot request doesn't wait for it
+			if (SnapshotViewerMode)
+				WebOne.SnapshotViewer.ScreenshotEngine.EnsureContextAsync().GetAwaiter().GetResult();
+
 			//start the server from 1 or 2 attempts
 			for (int StartAttempts = 0; StartAttempts < 2; StartAttempts++)
 			{
@@ -340,6 +352,7 @@ namespace WebOne
 			ShutdownInitiated = true;
 
 			if (Server != null && Server.Working) Server.Stop();
+			if (SnapshotViewerMode) WebOne.SnapshotViewer.ScreenshotEngine.ShutdownAsync().GetAwaiter().GetResult();
 
 			if (!DaemonMode && !Environment.HasShutdownStarted && !ShutdownInitiated) try
 				{
@@ -437,6 +450,47 @@ namespace WebOne
 						break;
 					case "--daemon":
 						DaemonMode = true;
+						break;
+					case "--web-snapshot-viewer":
+						SnapshotViewerMode = true;
+						Console.WriteLine("Web Snapshot Viewer mode enabled.");
+						break;
+					case "--snapshot-headed":
+						SnapshotViewerHeaded = true;
+						Console.WriteLine("Snapshot Viewer: browser will run in headed (visible) mode.");
+						break;
+					case "--quality":
+						if (int.TryParse(kvp.Value, out int q) && q >= 1 && q <= 100)
+						{
+							JpegQuality = q;
+							Console.WriteLine("JPEG quality set to {0}.", JpegQuality);
+						}
+						else
+						{
+							Console.WriteLine("Invalid --quality value: {0}. Expected a number between 1 and 100.", kvp.Value);
+						}
+						break;
+					case "--strip-size":
+						if (int.TryParse(kvp.Value, out int sh) && sh > 0)
+						{
+							StripHeight = sh;
+							Console.WriteLine("Strip height set to {0}px.", StripHeight);
+						}
+						else
+						{
+							Console.WriteLine("Invalid --strip-size value: {0}. Expected a positive number.", kvp.Value);
+						}
+						break;
+					case "--set-min-threads":
+						if (int.TryParse(kvp.Value, out int mt) && mt > 0)
+						{
+							MinThreads = mt;
+							Console.WriteLine("Min threads set to {0}.", MinThreads);
+						}
+						else
+						{
+							Console.WriteLine("Invalid --set-min-threads value: {0}. Expected a positive number.", kvp.Value);
+						}
 						break;
 					case "--help":
 					case "-?":

--- a/WebOne.csproj
+++ b/WebOne.csproj
@@ -170,7 +170,10 @@ fi
 
 	<ItemGroup>
 		<Compile Remove="EXE\**" />
+		<Compile Remove="tests\**" />
 		<EmbeddedResource Remove="EXE\**" />
+		<EmbeddedResource Remove="tests\**" />
+		<None Remove="tests\**" />
 		<None Remove="docs/**" />
 		<None Remove="EXE/**" />
 		<None Remove="EXE\**" />
@@ -191,6 +194,8 @@ fi
 	<ItemGroup>
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
 		<PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
+		<PackageReference Include="Microsoft.Playwright" Version="1.*" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="3.*" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/ScreenshotEngineTests.cs
+++ b/tests/ScreenshotEngineTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SnapshotViewerTests
+{
+    public class ScreenshotEngineTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public ScreenshotEngineTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task Firefox_LaunchesHeadless()
+        {
+            using var playwright = await Playwright.CreateAsync();
+            var browser = await playwright.Firefox.LaunchAsync(new BrowserTypeLaunchOptions
+            {
+                Headless = true
+            });
+
+            Assert.True(browser.IsConnected);
+            _output.WriteLine("Firefox launched OK.");
+            await browser.CloseAsync();
+        }
+
+        [Fact]
+        public async Task Firefox_NavigatesAndReturnsTitle()
+        {
+            using var playwright = await Playwright.CreateAsync();
+            await using var browser = await playwright.Firefox.LaunchAsync(new BrowserTypeLaunchOptions
+            {
+                Headless = true
+            });
+
+            var page = await browser.NewPageAsync();
+            await page.GotoAsync("https://example.com", new PageGotoOptions
+            {
+                WaitUntil = WaitUntilState.Load,
+                Timeout = 30000
+            });
+
+            string title = await page.TitleAsync();
+            _output.WriteLine($"Page title: {title}");
+
+            Assert.False(string.IsNullOrEmpty(title));
+            await page.CloseAsync();
+        }
+
+        [Fact]
+        public async Task Firefox_TakesFullPageScreenshot()
+        {
+            using var playwright = await Playwright.CreateAsync();
+            await using var browser = await playwright.Firefox.LaunchAsync(new BrowserTypeLaunchOptions
+            {
+                Headless = true
+            });
+
+            var page = await browser.NewPageAsync(new BrowserNewPageOptions
+            {
+                ViewportSize = new ViewportSize { Width = 1280, Height = 800 }
+            });
+
+            await page.GotoAsync("https://example.com", new PageGotoOptions
+            {
+                WaitUntil = WaitUntilState.Load,
+                Timeout = 30000
+            });
+
+            byte[] jpg = await page.ScreenshotAsync(new PageScreenshotOptions
+            {
+                FullPage = true,
+                Type = ScreenshotType.Jpeg,
+                Quality = 85
+            });
+
+            _output.WriteLine($"Screenshot size: {jpg.Length} bytes");
+
+            Assert.True(jpg.Length > 1000, "Screenshot should be larger than 1KB");
+            await page.CloseAsync();
+        }
+    }
+}

--- a/tests/SnapshotViewerTests.csproj
+++ b/tests/SnapshotViewerTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.58.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/web-snapshot-viewer/ARCHITECTURE.md
+++ b/web-snapshot-viewer/ARCHITECTURE.md
@@ -1,0 +1,244 @@
+# Architecture: `--web-snapshot-viewer`
+
+## General flow
+
+```
+Browser → Proxy → [has dimensions?]
+                    ├─ NO → Return "probe page" (minimal HTML with JS)
+                    │        Browser runs JS → redirects with dimensions → Proxy
+                    └─ YES → Playwright screenshot → HTML shell page with strip images
+```
+
+---
+
+## File structure
+
+```
+./web-snapshot-viewer/
+├── WebSnapshotViewer.cs      # HTTP router — dispatches all requests to the right handler
+├── DimensionProbe.cs         # Generates lightweight HTML to detect viewport w/h
+├── ScreenshotEngine.cs       # Playwright wrapper — screenshot, scroll, click
+├── SnapshotPage.cs           # Generates the shell page (strip IMGs + scripts)
+├── StripManager.cs           # Splits PNG into horizontal strips, hashes, encodes JPEG
+├── BlankStrip.cs             # Generates checkerboard placeholder GIF per session
+├── ScrollHandler.cs          # Scroll sync JS (inline) + /scroll-pos endpoint
+├── ClickHandler.cs           # Click overlay JS + /click endpoint
+└── ClientStripManager.cs     # JS helpers: sendCmd(), updateStrip(), reloadPage()
+```
+
+---
+
+## Interception point in the proxy
+
+```
+HttpTransit → [SnapshotViewerMode?]
+                ├─ YES → WebSnapshotViewer.Handle(request)
+                └─ NO  → normal proxy flow
+```
+
+`Program.cs` flags:
+```csharp
+public static bool SnapshotViewerMode   = false;  // --web-snapshot-viewer
+public static bool SnapshotViewerHeaded = false;  // --snapshot-headed
+public static int  JpegQuality          = 85;     // --quality
+public static int  StripHeight          = 100;    // --strip-size
+public static int  MinThreads           = 1000;   // --set-min-threads
+```
+
+Thread pool is raised at startup to avoid starvation (50 tabs × 6 connections = 300 concurrent requests):
+```csharp
+ThreadPool.SetMinThreads(MinThreads, MinThreads);
+```
+
+Browser driver is pre-warmed at startup so the first request doesn't wait:
+```csharp
+ScreenshotEngine.EnsureContextAsync().GetAwaiter().GetResult();
+```
+
+---
+
+## HTTP endpoints (all on `snapshot.webone.internal`)
+
+| Endpoint | Handler | Description |
+|---|---|---|
+| `GET /snap?url=...&w=...&h=...` | `HandleSnapshot` | Takes screenshot, returns shell page |
+| `GET /strip?key=...&i=...&r=...` | `HandleStrip` | Serves a single JPEG strip |
+| `GET /blank-strip?key=...` | `HandleBlankStrip` | Serves the placeholder GIF for unloaded strips |
+| `GET /click?key=...&x=...&y=...` | `HandleClick` | Forwards click to Playwright, returns strip update JS |
+| `GET /scroll-pos?key=...&y=...` | `HandleScrollPos` | Syncs scroll position to Playwright, returns 1×1 GIF |
+
+All other URLs → probe page (JS redirect with viewport dimensions).
+
+---
+
+## Detailed flow
+
+### Step 1 — Probe page
+
+Browser requests any URL → proxy has no dimensions → returns:
+```html
+<HTML><BODY><SCRIPT>
+var t="http://snapshot.webone.internal/snap";
+var u=encodeURIComponent(location.href);
+location.replace(t+"?url="+u+"&w="+window.innerWidth+"&h="+window.innerHeight);
+</SCRIPT></BODY></HTML>
+```
+Browser runs JS and redirects to `/snap` with its actual viewport dimensions.
+
+### Step 2 — Snapshot
+
+`/snap?url=...&w=...&h=...` → check cache → if miss:
+1. Playwright navigates to `url` with viewport `w × h`
+2. Takes full-page PNG screenshot
+3. `StripManager.CreateStrips()` splits PNG into horizontal strips of `StripHeight` px
+4. Each strip is hashed (SHA256 of raw pixels) and encoded as JPEG RGB
+5. A checkerboard placeholder GIF is generated for the session (`BlankStrip.Generate`)
+6. `StripSet` stored in cache (key = `SHA256(url + width)`, TTL = 5 min)
+7. Shell page returned
+
+---
+
+## Strip system
+
+### StripData
+```csharp
+class StripData {
+    byte[]  Hash;      // SHA256 of raw pixels — used to detect changes after clicks
+    byte[]  Jpeg;      // JPEG-encoded bytes served directly to browser
+    string  Revision;  // Unix timestamp ms — appended to URL to bust browser cache
+    int     Height;    // Pixel height of this strip (last strip may be shorter)
+}
+```
+
+### StripSet
+```csharp
+class StripSet {
+    StripData[] Strips;
+    int  ImageWidth, ImageHeight, StripHeight;
+    int  ViewportHeight, NumberStripsInViewport;
+    int  LastScrollY;
+    byte[] BlankStripGif;   // Per-session checkerboard GIF (same width as screenshot)
+    DateTime CreatedAt;
+}
+```
+
+### JPEG encoding
+Strips are encoded as **JPEG RGB** (`JpegEncodingColor.Rgb`) to avoid the YCbCr→RGB conversion crash in Safari 1 on Mac OS X 10.3 (`vec_ycc_rgb_convert` AltiVec bug).
+
+---
+
+## Shell page
+
+The shell page is a plain HTML document that:
+1. Has CSS `IMG { display:block; width:100% }` so strips fill the full width
+2. Contains one `<IMG>` per strip — only the first `NumberStripsInViewport + 2` get a real SRC; the rest get `/blank-strip?key=...` (lazy loading)
+3. Has a hidden `<IFRAME NAME="cmd">` used as an AJAX equivalent for Safari 1 — JS navigates it to `/click?...` and the server returns JS that updates strip images
+4. Includes the click overlay `<DIV>` that captures all clicks
+5. Inlines the scroll script (no separate request needed)
+
+```
+<HTML>
+  <HEAD>
+    <STYLE> IMG { width:100% } </STYLE>
+    <SCRIPT> ClientStripManager JS (sendCmd, updateStrip) </SCRIPT>
+    <SCRIPT> ScrollHandler JS (_srcs[], _scroll, _sendScroll, _loadStrips) </SCRIPT>
+  </HEAD>
+  <BODY>
+    <IMG id="strip0" src="/strip?key=...&i=0&r=...">   ← real (in viewport)
+    <IMG id="strip1" src="/strip?key=...&i=1&r=...">   ← real (in viewport)
+    ...
+    <IMG id="stripN" src="/blank-strip?key=...">        ← placeholder (lazy)
+    <IFRAME NAME="cmd" style="position:absolute;left:-9999px">
+    <DIV id="_ov" style="position:absolute;top:0;z-index:9999"> ← click overlay
+    <SCRIPT> click overlay JS </SCRIPT>
+  </BODY>
+</HTML>
+```
+
+---
+
+## Scroll system
+
+The inline scroll script runs every 200ms via `setInterval` and also on `window.onscroll` (modern browsers):
+
+```javascript
+var _srcs = ['...url for strip 0...', '...url for strip 1...', ...];
+
+function _getScrollY() { return window.pageYOffset || 0; }
+
+function _sendScroll(sy) {
+    new Image().src = '/scroll-pos?key=...&y=' + sy + '&t=' + Date.now();
+}
+
+function _loadStrips(sy) {
+    var first = Math.floor(sy / stripHeight);
+    var last  = Math.min(images.length - 1, first + visibleStrips + 2);
+    for (var i = first; i <= last; i++)
+        document.images[i].src = _srcs[i];
+}
+
+function _scroll() {
+    var sy = _getScrollY();
+    if (sy == _lastY) return;
+    _lastY = sy;
+    _loadStrips(sy);
+    _sendScroll(sy);
+}
+
+window.onscroll = _scroll;
+setInterval('_scroll()', 200);
+```
+
+`/scroll-pos` handler calls `ScreenshotEngine.ScrollTo(key, y)` which runs `window.scrollTo(0, y)` in Playwright via JS evaluation. Returns a 1×1 transparent GIF so the `new Image()` request completes cleanly.
+
+---
+
+## Click system
+
+The click overlay `<DIV>` covers the full page (`position:absolute; z-index:9999`). On click:
+
+```javascript
+var pointerX = e.pageX || 0;
+var pointerY = e.pageY || 0;
+var px = Math.round(pointerX * _sc);   // scale to screenshot pixels
+var py = Math.round(pointerY * _sc);
+sendCmd('/click?key=...&x=' + px + '&y=' + py);
+```
+
+`sendCmd()` navigates the hidden `cmd` iframe to `/click?...`.
+
+Server side (`ClickHandler.Handle`):
+1. Calls `ScreenshotEngine.ClickAndScreenshot(key, x, y)`
+2. Playwright scrolls to bring `y` into viewport, then `Mouse.ClickAsync(x, viewportY)`
+3. Waits for navigation (3s timeout) or settles for JS-only changes
+4. Takes new full-page PNG
+5. `StripManager.UpdateStrips()` compares hashes — only changed strips get new JPEG + revision
+6. Returns a JS page (loaded by the `cmd` iframe) that calls `parent.updateStrip(id, url)` for each changed strip
+7. If strip count changed (page height changed) → `parent.reloadPage()` instead
+
+---
+
+## Cache
+
+```csharp
+private static readonly Dictionary<string, StripSet> Cache = new();
+private static readonly TimeSpan CacheTTL = TimeSpan.FromMinutes(5);
+```
+
+Key = `SHA256(url + ":" + width)` as hex string. Height is excluded because full-page screenshots capture all content regardless of viewport height.
+
+---
+
+## Key design decisions
+
+| Decision | Choice | Reason |
+|---|---|---|
+| Image format | JPEG RGB | Avoids YCbCr→RGB AltiVec crash in Safari 1 on PPC |
+| Strip height | 100px default (`--strip-size`) | Balance between number of HTTP requests and RAM per strip |
+| Lazy loading | Only first `viewport/stripHeight + 2` strips load | Avoids flooding old browsers with 30+ simultaneous image requests |
+| Blank strip | Checkerboard GIF per session | Shows placeholder while strip loads instead of black/white |
+| Scroll detection | `setInterval(200)` + `window.onscroll` | Safari 1 has no `onscroll` event; `setInterval` as fallback |
+| Scroll sync | `new Image()` fire-and-forget GET | Most compatible async request for Safari 1 (no XHR) |
+| Click transport | Hidden `cmd` iframe navigation | Safari 1 compatible AJAX equivalent |
+| Thread pool | `SetMinThreads(1000, 1000)` | Prevents starvation with many concurrent strip requests |
+| Browser pre-warm | `EnsureContextAsync()` at startup | First request doesn't wait for Playwright to launch |

--- a/web-snapshot-viewer/BlankStrip.cs
+++ b/web-snapshot-viewer/BlankStrip.cs
@@ -1,0 +1,43 @@
+using System.IO;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Gif;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace WebOne.SnapshotViewer
+{
+	/// <summary>
+	/// Generates a checkerboard placeholder GIF stored in RAM,
+	/// used as src for strips not yet loaded.
+	/// </summary>
+	static class BlankStrip
+	{
+		private static readonly Color White     = Color.FromRgb(255, 255, 255);
+		private static readonly Color LightGray = Color.FromRgb(204, 204, 204);
+
+		/// <summary>
+		/// Generates a checkerboard GIF of the given dimensions and returns it as bytes.
+		/// Pattern: 10x10px squares alternating white and light gray.
+		/// </summary>
+		public static byte[] Generate(int width, int height)
+		{
+			using var image = new Image<Rgba32>(width, height);
+
+			image.ProcessPixelRows(accessor =>
+			{
+				for (int y = 0; y < height; y++)
+				{
+					var row = accessor.GetRowSpan(y);
+					for (int x = 0; x < width; x++)
+					{
+						bool isGray = ((x / 10) + (y / 10)) % 2 == 0;
+						row[x] = isGray ? LightGray.ToPixel<Rgba32>() : White.ToPixel<Rgba32>();
+					}
+				}
+			});
+
+			using var ms = new MemoryStream();
+			image.SaveAsGif(ms, new GifEncoder { ColorTableMode = GifColorTableMode.Global });
+			return ms.ToArray();
+		}
+	}
+}

--- a/web-snapshot-viewer/ClickHandler.cs
+++ b/web-snapshot-viewer/ClickHandler.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace WebOne.SnapshotViewer
+{
+	/// <summary>
+	/// Handles click interactivity for the web snapshot viewer.
+	///
+	/// Flow:
+	///   1. User clicks anywhere in the view page.
+	///   2. JS (from <see cref="GetClickScript"/>) captures coordinates, scales them,
+	///      and navigates the hidden cmd iframe to /click?key=X&amp;x=Y&amp;y=Z.
+	///   3. <see cref="Handle"/> forwards the click to Playwright, compares strips,
+	///      and returns a small JS page that updates only the changed strip iframes.
+	///   4. Unchanged strip iframes are never touched — the browser keeps them cached.
+	/// </summary>
+	static class ClickHandler
+	{
+		/// <summary>
+		/// Returns a transparent absolutely-positioned overlay div that covers the entire page
+		/// and captures all clicks, plus the JS that scales coordinates and forwards them to
+		/// the hidden cmd iframe. Compatible with Safari 1 (CSS2 position:absolute).
+		/// </summary>
+		public static string GetClickScript(string sessionKey, int screenshotWidth, int screenshotHeight)
+		{
+			return
+				// Overlay sits on top of all strip iframes via z-index and catches every click.
+				"<DIV ID=\"_ov\" STYLE=\"position:absolute;top:0;left:0;width:100%;z-index:9999;cursor:pointer\"></DIV>" +
+				"<SCRIPT LANGUAGE=\"JavaScript\">" +
+				"var _key='" + sessionKey + "';" +
+				"var _sw=" + screenshotWidth + ";" +
+				"var _sh=" + screenshotHeight + ";" +
+				"var _ov=document.getElementById('_ov');" +
+				// Size overlay to cover all strips at the browser's display scale.
+				"var _sc=(_sw>0&&window.innerWidth>0)?(_sw/window.innerWidth):1;" +
+				"_ov.style.height=Math.ceil(_sh/_sc)+'px';" +
+				"_ov.onclick=function(e){" +
+				  "e=e||window.event;" +
+				  "var px=e.pageX || 0;" +
+				  "var py=e.pageY || 0;" +
+				  //"var px=Math.round(pointerX*_sc);" +
+				  //"var py=Math.round(pointerY*_sc);" +
+				  "sendCmd('http://" + DimensionProbe.MagicHost + "/click?key='+_key+'&x='+px+'&y='+py);" +
+				"};" +
+				"</SCRIPT>";
+		}
+
+		/// <summary>
+		/// Processes a click: forwards to Playwright, compares strips, returns a JS page
+		/// that updates only the changed strip iframes in the parent (view) document.
+		/// If the page height changed (new strips added/removed), forces a full view reload instead.
+		/// </summary>
+		public static void Handle(
+			Uri requestUrl,
+			HttpRequest clientRequest,
+			HttpResponse clientResponse,
+			LogWriter log,
+			Dictionary<string, StripSet> cache)
+		{
+			var qs = HttpUtility.ParseQueryString(requestUrl.Query);
+			string key = qs["key"];
+			string xStr = qs["x"];
+			string yStr = qs["y"];
+
+			if (string.IsNullOrEmpty(key) || !int.TryParse(xStr, out int x) || !int.TryParse(yStr, out int y))
+			{
+				SendHtml(clientResponse, "<HTML><BODY><H1>Invalid click request.</H1></BODY></HTML>");
+				return;
+			}
+
+			log.WriteLine(" [Click] key={0} x={1} y={2}", key, x, y);
+
+			byte[] newPng;
+			try
+			{
+				newPng = Task.Run(() => ScreenshotEngine.ClickAndScreenshot(key, x, y)).GetAwaiter().GetResult();
+			}
+			catch (Exception ex)
+			{
+				log.WriteLine(" [Click] Error: {0}", ex.Message);
+				SendHtml(clientResponse,
+					"<HTML><BODY><H1>Click failed</H1>" +
+					"<PRE>" + HttpUtility.HtmlEncode(ex.Message) + "</PRE>" +
+					"</BODY></HTML>");
+				return;
+			}
+
+			if (newPng == null)
+			{
+				log.WriteLine(" [Click] Session not found for key={0}", key);
+				SendHtml(clientResponse, "<HTML><BODY><H1>Session expired. Please reload.</H1></BODY></HTML>");
+				return;
+			}
+
+			if (!cache.TryGetValue(key, out var stripSet))
+			{
+				SendHtml(clientResponse, "<HTML><BODY><H1>Strip set not found.</H1></BODY></HTML>");
+				return;
+			}
+
+			int oldCount = stripSet.Strips.Length;
+			List<int> changed = StripManager.UpdateStrips(stripSet, newPng);
+			bool heightChanged = stripSet.Strips.Length != oldCount;
+
+			log.WriteLine(" [Click] {0} strip(s) changed.", changed.Count);
+
+			if (heightChanged)
+			{
+				// Page height changed — full view reload needed to add/remove strip iframes.
+				log.WriteLine(" [Click] Strip count changed ({0} -> {1}), forcing view reload.", oldCount, stripSet.Strips.Length);
+				SendHtml(clientResponse, ClientStripManager.BuildViewReload(key));
+				return;
+			}
+
+			// Partial update — JS updates only the changed strip images.
+			SendHtml(clientResponse, ClientStripManager.BuildPartialUpdate(key, stripSet, changed));
+		}
+
+		private static void SendHtml(HttpResponse response, string html)
+		{
+			byte[] buffer = Encoding.UTF8.GetBytes(html);
+			response.StatusCode = 200;
+			response.ContentType = "text/html";
+			response.ContentLength64 = buffer.Length;
+			response.SendHeaders();
+			response.OutputStream.Write(buffer, 0, buffer.Length);
+			response.Close();
+		}
+	}
+}

--- a/web-snapshot-viewer/ClientStripManager.cs
+++ b/web-snapshot-viewer/ClientStripManager.cs
@@ -1,0 +1,115 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace WebOne.SnapshotViewer
+{
+	/// <summary>
+	/// Manages all client-side strip rendering and updates.
+	///
+	/// Client-side JS (injected via GetScript):
+	///   - sendCmd(url)          — navigates the cmd iframe to send a request to the server
+	///   - updateStrip(name,url) — updates the src of a strip image element
+	///   - reloadPage()          — reloads the shell page
+	///
+	/// Server-side builders (responses loaded inside the cmd iframe):
+	///   - BuildPartialUpdate    — updates only changed strips
+	///   - BuildViewportUpdate   — updates only visible strips
+	///   - BuildFullUpdate       — updates all strips
+	///   - BuildViewReload       — reloads the shell page
+	/// </summary>
+	static class ClientStripManager
+	{
+		/// <summary>
+		/// Returns the JS library injected into the shell page.
+		/// Must be included before any other script that uses these functions.
+		/// </summary>
+		public static string GetScript()
+		{
+			return
+				// Navigates the cmd iframe to send a request to the server.
+				"function sendCmd(url){" +
+				  "window.frames['cmd'].location=url;" +
+				"}" +
+				// Updates the src of a strip image element directly.
+				"function updateStrip(name,url){" +
+				  "var img=document.getElementById(name);" +
+				  "if(img)img.src=url;" +
+				"}" +
+				// Reloads the shell page to rebuild all strip images.
+				"function reloadPage(){" +
+				  "window.location=window.location.href;" +
+				"}";
+		}
+
+		/// <summary>
+		/// Builds a JS page loaded in the cmd iframe that updates only the changed strips.
+		/// </summary>
+		public static string BuildPartialUpdate(string key, StripSet strips, List<int> changed)
+		{
+			var sb = new StringBuilder();
+			sb.Append("<HTML><BODY><SCRIPT LANGUAGE=\"JavaScript\">");
+
+			foreach (int i in changed)
+			{
+				string url = "http://" + DimensionProbe.MagicHost +
+				             "/strip?key=" + key +
+				             "&i=" + i +
+				             "&r=" + strips.Strips[i].Revision;
+				sb.Append("parent.updateStrip('strip" + i + "','" + url + "');");
+			}
+
+			sb.Append("</SCRIPT></BODY></HTML>");
+			return sb.ToString();
+		}
+
+		/// <summary>
+		/// Builds a JS page loaded in the cmd iframe that updates only the strips
+		/// currently visible in the driver viewport.
+		/// </summary>
+		public static string BuildViewportUpdate(string key, StripSet strips)
+		{
+			int scrollY    = strips.LastScrollY;
+			int vpHeight   = strips.ViewportHeight > 0 ? strips.ViewportHeight : strips.ImageHeight;
+			int firstStrip = System.Math.Max(0, scrollY / strips.StripHeight);
+			int lastStrip  = System.Math.Min(strips.Strips.Length - 1, (scrollY + vpHeight) / strips.StripHeight);
+
+			var sb = new StringBuilder();
+			sb.Append("<HTML><BODY><SCRIPT LANGUAGE=\"JavaScript\">");
+
+			for (int i = firstStrip; i <= lastStrip; i++)
+			{
+				string url = "http://" + DimensionProbe.MagicHost +
+				             "/strip?key=" + key +
+				             "&i=" + i +
+				             "&r=" + strips.Strips[i].Revision;
+				sb.Append("parent.updateStrip('strip" + i + "','" + url + "');");
+			}
+
+			sb.Append("</SCRIPT></BODY></HTML>");
+			return sb.ToString();
+		}
+
+		/// <summary>
+		/// Builds a JS page loaded in the cmd iframe that updates all strips.
+		/// </summary>
+		public static string BuildFullUpdate(string key, StripSet strips)
+		{
+			var changed = new List<int>(strips.Strips.Length);
+			for (int i = 0; i < strips.Strips.Length; i++)
+				changed.Add(i);
+			return BuildPartialUpdate(key, strips, changed);
+		}
+
+		/// <summary>
+		/// Builds a JS page loaded in the cmd iframe that reloads the shell page.
+		/// Used when the strip count changed and images need to be recreated.
+		/// </summary>
+		public static string BuildViewReload(string key)
+		{
+			return
+				"<HTML><BODY><SCRIPT LANGUAGE=\"JavaScript\">" +
+				"parent.reloadPage();" +
+				"</SCRIPT></BODY></HTML>";
+		}
+	}
+}

--- a/web-snapshot-viewer/DimensionProbe.cs
+++ b/web-snapshot-viewer/DimensionProbe.cs
@@ -1,0 +1,29 @@
+using System.Web;
+
+namespace WebOne.SnapshotViewer
+{
+	/// <summary>
+	/// Generates a lightweight HTML page that detects browser viewport dimensions
+	/// and redirects to the snapshot endpoint with those dimensions.
+	/// </summary>
+	static class DimensionProbe
+	{
+		internal const string MagicHost = "snapshot.webone.internal";
+
+		/// <summary>
+		/// Returns an HTML probe page that reads window.innerWidth/innerHeight and redirects
+		/// to the snapshot endpoint with the original URL and detected dimensions.
+		/// </summary>
+		/// <param name="originalUrl">The original URL the browser was trying to reach.</param>
+		public static string GetPage(string originalUrl)
+		{
+			string safeUrl = HttpUtility.JavaScriptStringEncode(originalUrl);
+			return
+				"<!DOCTYPE html><html><head><title>Loading snapshot...</title></head><body><script>" +
+				"var t='http://" + MagicHost + "/snap';" +
+				"var u=encodeURIComponent('" + safeUrl + "');" +
+				"location.replace(t+'?url='+u+'&w='+window.innerWidth+'&h='+window.innerHeight);" +
+				"</script></body></html>";
+		}
+	}
+}

--- a/web-snapshot-viewer/ScreenshotEngine.cs
+++ b/web-snapshot-viewer/ScreenshotEngine.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace WebOne.SnapshotViewer
+{
+	/// <summary>
+	/// Takes full-page PNG screenshots using Playwright/Firefox.
+	/// Keeps a single browser context (with animations disabled) and open pages alive.
+	/// </summary>
+	static class ScreenshotEngine
+	{
+		private static IPlaywright _playwright;
+		private static IBrowser _browser;
+		private static IBrowserContext _context;
+		private static readonly SemaphoreSlim _browserLock = new SemaphoreSlim(1, 1);
+
+		// CSS injected into every page to disable transitions and animations instantly.
+		private const string DisableAnimationsScript =
+			"const _s = document.createElement('style');" +
+			"_s.textContent = '*, *::before, *::after {" +
+				"animation: none !important;" +
+				"animation-duration: 0s !important;" +
+				"animation-delay: 0s !important;" +
+				"transition: none !important;" +
+				"transition-duration: 0s !important;" +
+				"transition-delay: 0s !important;" +
+				"scroll-behavior: auto !important;" +
+			"}';" +
+			"(document.head || document.documentElement).appendChild(_s);";
+
+		// Active pages kept alive per session key so clicks can be forwarded.
+		private static readonly Dictionary<string, IPage> _sessions = new();
+		private static readonly SemaphoreSlim _sessionsLock = new SemaphoreSlim(1, 1);
+
+		/// <summary>
+		/// Navigates to <paramref name="url"/> at the given viewport size, takes a full-page
+		/// PNG screenshot, and keeps the page open for future click interactions.
+		/// </summary>
+		public static async Task<byte[]> TakeScreenshot(string sessionKey, string url, int width, int height)
+		{
+			await EnsureContextAsync();
+			await CloseSessionAsync(sessionKey);
+
+			var page = await _context.NewPageAsync();
+			await page.SetViewportSizeAsync(width, height);
+
+			await page.GotoAsync(url, new PageGotoOptions
+			{
+				WaitUntil = WaitUntilState.Load,
+				Timeout = 30000
+			});
+
+			byte[] png = await page.ScreenshotAsync(new PageScreenshotOptions
+			{
+				FullPage = true,
+				Type = ScreenshotType.Png
+			});
+
+			await _sessionsLock.WaitAsync();
+			try { _sessions[sessionKey] = page; }
+			finally { _sessionsLock.Release(); }
+
+			return png;
+		}
+
+		/// <summary>
+		/// Scrolls the page to the given Y position without taking a screenshot.
+		/// </summary>
+		public static async Task ScrollTo(string sessionKey, int scrollY)
+		{
+			IPage page;
+			await _sessionsLock.WaitAsync();
+			try
+			{
+				if (!_sessions.TryGetValue(sessionKey, out page)) return;
+			}
+			finally { _sessionsLock.Release(); }
+
+			await page.EvaluateAsync("(y) => window.scrollTo(0, y)", scrollY);
+		}
+
+		/// <summary>
+		/// Takes a full-page PNG screenshot of the current page state without navigating.
+		/// Returns null if the session is not found.
+		/// </summary>
+		public static async Task<byte[]> Screenshot(string sessionKey)
+		{
+			IPage page;
+			await _sessionsLock.WaitAsync();
+			try
+			{
+				if (!_sessions.TryGetValue(sessionKey, out page)) return null;
+			}
+			finally { _sessionsLock.Release(); }
+
+			return await page.ScreenshotAsync(new PageScreenshotOptions
+			{
+				FullPage = true,
+				Type = ScreenshotType.Png
+			});
+		}
+
+		/// <summary>
+		/// Clicks at the given page coordinates, waits for any resulting navigation or DOM
+		/// changes to settle, then returns a new full-page PNG screenshot.
+		/// Returns null if the session is not found.
+		/// </summary>
+		public static async Task<byte[]> ClickAndScreenshot(string sessionKey, int x, int y)
+		{
+			IPage page;
+			await _sessionsLock.WaitAsync();
+			try
+			{
+				if (!_sessions.TryGetValue(sessionKey, out page)) return null;
+			}
+			finally { _sessionsLock.Release(); }
+
+			// Register navigation listener BEFORE clicking to avoid race condition.
+			var navigationTask = page.WaitForNavigationAsync(new PageWaitForNavigationOptions
+			{
+				WaitUntil = WaitUntilState.Load,
+				Timeout = 3000
+			});
+
+			await page.EvaluateAsync("(y) => window.scrollTo(0, y - window.innerHeight/2)", y);
+			int scrollY = await page.EvaluateAsync<int>("window.scrollY");
+			await page.Mouse.ClickAsync(x, y - scrollY);
+
+			try
+			{
+				await navigationTask;
+			}
+			catch (TimeoutException)
+			{
+				// No navigation — JS-only interaction (dropdown, modal, etc.)
+			}
+
+			return await Screenshot(sessionKey);
+		}
+
+		private static async Task CloseSessionAsync(string sessionKey)
+		{
+			await _sessionsLock.WaitAsync();
+			try
+			{
+				if (_sessions.TryGetValue(sessionKey, out var old))
+				{
+					_sessions.Remove(sessionKey);
+					try { await old.CloseAsync(); } catch { /* already closed */ }
+				}
+			}
+			finally { _sessionsLock.Release(); }
+		}
+
+		public static async Task EnsureContextAsync()
+		{
+			if (_context != null) return;
+
+			await _browserLock.WaitAsync();
+			try
+			{
+				if (_context != null) return;
+
+				_playwright = await Playwright.CreateAsync();
+				_browser = await _playwright.Firefox.LaunchAsync(new BrowserTypeLaunchOptions
+				{
+					Headless = !Program.SnapshotViewerHeaded
+				});
+
+				// Create a shared context with reduced motion and no animations.
+				_context = await _browser.NewContextAsync(new BrowserNewContextOptions
+				{
+					ReducedMotion = ReducedMotion.Reduce
+				});
+
+				// Inject the animation-disabling CSS into every page before any scripts run.
+				await _context.AddInitScriptAsync(DisableAnimationsScript);
+			}
+			finally
+			{
+				_browserLock.Release();
+			}
+		}
+
+		/// <summary>
+		/// Shuts down all open pages, the browser context, and the browser. Call on proxy shutdown.
+		/// </summary>
+		public static async Task ShutdownAsync()
+		{
+			foreach (var page in _sessions.Values)
+				try { await page.CloseAsync(); } catch { }
+			_sessions.Clear();
+
+			if (_context != null) try { await _context.CloseAsync(); } catch { }
+			if (_browser != null) try { await _browser.CloseAsync(); } catch { }
+			_playwright?.Dispose();
+		}
+	}
+}

--- a/web-snapshot-viewer/ScrollHandler.cs
+++ b/web-snapshot-viewer/ScrollHandler.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace WebOne.SnapshotViewer
+{
+	/// <summary>
+	/// Keeps the Playwright driver scroll position in sync with the client browser.
+	/// </summary>
+	static class ScrollHandler
+	{
+		// 1×1 transparent GIF returned so the browser Image() request completes cleanly.
+		private static readonly byte[] TransparentGif = Convert.FromBase64String(
+			"R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7");
+
+		/// <summary>
+		/// Returns the scroll-sync JS served at /scroll.js.
+		/// ES3-only, Safari 1 compatible.
+		/// </summary>
+		public static string GetScrollScript(string sessionKey, StripSet strips)
+		{
+			string scrollBase = "http://" + DimensionProbe.MagicHost + "/scroll-pos?key=" + sessionKey + "&y=";
+			string stripBase  = "http://" + DimensionProbe.MagicHost + "/strip?key=" + sessionKey + "&i=";
+
+			// Build strip URL array: _srcs[i] = url for strip i.
+			var srcs = new System.Text.StringBuilder();
+			srcs.Append("var _srcs=[");
+			for (int i = 0; i < strips.Strips.Length; i++)
+			{
+				if (i > 0) srcs.Append(",");
+				srcs.Append("'" + stripBase + i + "&r=" + strips.Strips[i].Revision + "'");
+			}
+			srcs.Append("];");
+
+			return
+				srcs.ToString() +
+				"function _getScrollY(){" +
+				  "if(window.pageYOffset!=null)return window.pageYOffset;" +
+				  "return 0;" +
+				"}" +
+				"function _sendScroll(sy){" +
+				  "var img=new Image();" +
+				  "img.src='" + scrollBase + "'+sy+'&t='+(new Date().getTime());" +
+				"}" +
+				"function _loadStrips(sy){" +
+				  "var firstStrip=Math.floor(sy/" + strips.StripHeight + ");" +
+				  "var lastStrip=Math.min(document.images.length-1,firstStrip+" + strips.NumberStripsInViewport + "+2);" +
+				  "for(var i=firstStrip;i<=lastStrip;i++){" +
+				    "document.images[i].src=_srcs[i];" +
+				  "}" +
+				"}" +
+				"var _lastY=_getScrollY();" +
+				"function _scroll(){" +
+				  "var sy=_getScrollY();" +
+				  "if(sy==_lastY)return;" +
+				  "_lastY=sy;" +
+				  "_loadStrips(sy);" +
+				  "_sendScroll(sy);" +
+				  "window.status='scroll y='+sy;" +
+				"}" +
+				"window.onscroll=_scroll;" +
+				"setInterval('_scroll()',200);";
+		}
+
+		/// <summary>
+		/// Serves the scroll-sync JS at /scroll.js.
+		/// <summary>
+		/// Scrolls the Playwright page to the given Y position.
+		/// Returns a 1×1 transparent GIF so the browser Image() request completes.
+		/// </summary>
+		public static void HandleScrollPos(
+			Uri requestUrl,
+			HttpResponse clientResponse,
+			LogWriter log,
+			Dictionary<string, StripSet> cache)
+		{
+			var qs = HttpUtility.ParseQueryString(requestUrl.Query);
+			string key = qs["key"];
+			string yStr = qs["y"];
+
+			if (!string.IsNullOrEmpty(key) && int.TryParse(yStr, out int scrollY))
+			{
+				log.WriteLine(" [ScrollPos] y={0}", scrollY);
+				Console.WriteLine("[ScrollPos] y={0}", scrollY);
+				if (cache.TryGetValue(key, out var stripSet))
+					stripSet.LastScrollY = scrollY;
+				Task.Run(() => ScreenshotEngine.ScrollTo(key, scrollY));
+			}
+
+			clientResponse.StatusCode = 200;
+			clientResponse.ContentType = "image/gif";
+			clientResponse.ContentLength64 = TransparentGif.Length;
+			clientResponse.SendHeaders();
+			clientResponse.OutputStream.Write(TransparentGif, 0, TransparentGif.Length);
+			clientResponse.Close();
+		}
+	}
+}

--- a/web-snapshot-viewer/SnapshotPage.cs
+++ b/web-snapshot-viewer/SnapshotPage.cs
@@ -1,0 +1,57 @@
+using System.Text;
+
+namespace WebOne.SnapshotViewer
+{
+	/// <summary>
+	/// Generates the HTML shell page of the snapshot viewer.
+	/// The shell page scrolls directly and contains strip images, the cmd iframe,
+	/// a click overlay, and scroll script.
+	/// </summary>
+	static class SnapshotPage
+	{
+		/// <summary>
+		/// Shell page. Contains strip images, cmd iframe, click overlay, and scroll script.
+		/// </summary>
+		public static string GetShellPage(string sessionKey, StripSet strips)
+		{
+var sb = new StringBuilder();
+			sb.Append("<HTML><HEAD><TITLE>Snapshot</TITLE>");
+			sb.Append("<STYLE TYPE=\"text/css\">");
+			sb.Append("HTML,BODY{margin:0;padding:0;background:#fff;font-size:0;line-height:0}");
+			sb.Append("IMG{display:block;width:100%;border:0;margin:0;padding:0;vertical-align:top}");
+			sb.Append("</STYLE>");
+			sb.Append("<SCRIPT LANGUAGE=\"JavaScript\">");
+			sb.Append(ClientStripManager.GetScript());
+			sb.Append("</SCRIPT>");
+			sb.Append("<SCRIPT LANGUAGE=\"JavaScript\">");
+			sb.Append(ScrollHandler.GetScrollScript(sessionKey, strips));
+			sb.Append("</SCRIPT>");
+			sb.Append("</HEAD><BODY>");
+
+			for (int i = 0; i < strips.Strips.Length; i++)
+			{
+				string src = i < strips.NumberStripsInViewport + 2
+					? "http://" + DimensionProbe.MagicHost + "/strip?key=" + sessionKey + "&i=" + i + "&r=" + strips.Strips[i].Revision
+					: "http://" + DimensionProbe.MagicHost + "/blank-strip?key=" + sessionKey;
+				sb.Append(
+					"<IMG ID=\"strip" + i + "\"" +
+					" SRC=\"" + src + "\"" +
+					" WIDTH=\"100%\"" +
+					" HEIGHT=\"" + strips.Strips[i].Height + "\"" +
+					" ALT=\"\">");
+			}
+
+			// Hidden cmd iframe — receives click/scroll responses and updates strip images via JS.
+			sb.Append(
+				"<IFRAME NAME=\"cmd\"" +
+				" SRC=\"about:blank\"" +
+				" FRAMEBORDER=\"0\" SCROLLING=\"NO\"" +
+				" STYLE=\"position:absolute;left:-9999px;width:1px;height:1px\">" +
+				"</IFRAME>");
+
+			sb.Append(ClickHandler.GetClickScript(sessionKey, strips.ImageWidth, strips.ImageHeight));
+			sb.Append("</BODY></HTML>");
+			return sb.ToString();
+		}
+	}
+}

--- a/web-snapshot-viewer/StripManager.cs
+++ b/web-snapshot-viewer/StripManager.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace WebOne.SnapshotViewer
+{
+	/// <summary>
+	/// A single horizontal strip of a page screenshot.
+	/// </summary>
+	class StripData
+	{
+		/// <summary>SHA256 of the strip's raw RGB pixels. Used to detect changes.</summary>
+		public byte[] Hash;
+		/// <summary>JPEG-encoded bytes of this strip. Served directly to the browser.</summary>
+		public byte[] Jpeg;
+		/// <summary>Timestamp string appended to the image URL to bust browser cache on change.</summary>
+		public string Revision;
+		/// <summary>Height of this strip in screenshot pixels.</summary>
+		public int Height;
+	}
+
+	/// <summary>
+	/// The full set of strips for one page snapshot session.
+	/// </summary>
+	class StripSet
+	{
+		public StripData[] Strips;
+		public int ImageWidth;
+		public int ImageHeight;
+		public int StripHeight;
+		public int ViewportHeight;
+		public int NumberStripsInViewport;
+		public int LastScrollY;
+		public byte[] BlankStripGif;
+		public DateTime CreatedAt;
+	}
+
+	/// <summary>
+	/// Splits PNG screenshots into horizontal strips, hashes each strip for change detection,
+	/// and encodes changed strips to JPEG for serving.
+	/// </summary>
+	static class StripManager
+	{
+		/// <summary>
+		/// Creates a <see cref="StripSet"/> from a full-page PNG screenshot.
+		/// </summary>
+		public static StripSet CreateStrips(byte[] png, int stripHeight, int viewportHeight = 0)
+		{
+			using var image = Image.Load<Rgb24>(png);
+			int count = (int)Math.Ceiling((double)image.Height / stripHeight);
+			string rev = Revision();
+			var strips = new StripData[count];
+
+			for (int i = 0; i < count; i++)
+			{
+				int y = i * stripHeight;
+				int h = Math.Min(stripHeight, image.Height - y);
+				using var strip = image.Clone(ctx => ctx.Crop(new Rectangle(0, y, image.Width, h)));
+				strips[i] = new StripData
+				{
+					Hash = Hash(strip),
+					Jpeg = EncodeJpeg(strip),
+					Revision = rev,
+					Height = h
+				};
+			}
+
+			return new StripSet
+			{
+				Strips = strips,
+				ImageWidth = image.Width,
+				ImageHeight = image.Height,
+				StripHeight = stripHeight,
+				ViewportHeight = viewportHeight,
+				NumberStripsInViewport = viewportHeight / stripHeight,
+				BlankStripGif = BlankStrip.Generate(image.Width, stripHeight),
+				CreatedAt = DateTime.UtcNow
+			};
+		}
+
+		/// <summary>
+		/// Compares a new PNG screenshot against an existing <see cref="StripSet"/> and updates
+		/// only the strips that changed. Unchanged strips keep their existing JPEG and revision.
+		/// </summary>
+		/// <returns>Indices of strips that changed.</returns>
+		public static List<int> UpdateStrips(StripSet existing, byte[] newPng)
+		{
+			var changed = new List<int>();
+			using var image = Image.Load<Rgb24>(newPng);
+			int count = (int)Math.Ceiling((double)image.Height / existing.StripHeight);
+			string rev = Revision();
+
+			// Resize strips array if page height changed
+			if (count != existing.Strips.Length)
+			{
+				var resized = new StripData[count];
+				Array.Copy(existing.Strips, resized, Math.Min(existing.Strips.Length, count));
+				for (int i = existing.Strips.Length; i < count; i++)
+					resized[i] = new StripData { Hash = Array.Empty<byte>(), Jpeg = Array.Empty<byte>(), Revision = "0" };
+				existing.Strips = resized;
+			}
+
+			for (int i = 0; i < count; i++)
+			{
+				int y = i * existing.StripHeight;
+				int h = Math.Min(existing.StripHeight, image.Height - y);
+				using var strip = image.Clone(ctx => ctx.Crop(new Rectangle(0, y, image.Width, h)));
+				byte[] newHash = Hash(strip);
+
+				if (!HashEqual(existing.Strips[i]?.Hash, newHash))
+				{
+					existing.Strips[i] = new StripData
+					{
+						Hash = newHash,
+						Jpeg = EncodeJpeg(strip),
+						Revision = rev,
+						Height = h
+					};
+					changed.Add(i);
+				}
+			}
+
+			existing.ImageWidth = image.Width;
+			existing.ImageHeight = image.Height;
+			return changed;
+		}
+
+		private static byte[] Hash(Image<Rgb24> image)
+		{
+			// Copy raw RGB pixel bytes and hash them — deterministic and lossless.
+			var pixelBytes = new byte[image.Width * image.Height * 3];
+			image.CopyPixelDataTo(pixelBytes);
+			return SHA256.HashData(pixelBytes);
+		}
+
+		private static byte[] EncodeJpeg(Image<Rgb24> image)
+		{
+			using var ms = new MemoryStream();
+			image.SaveAsJpeg(ms, new JpegEncoder { Quality = Program.JpegQuality, ColorType = JpegEncodingColor.Rgb });
+			return ms.ToArray();
+		}
+
+		private static bool HashEqual(byte[] a, byte[] b)
+		{
+			if (a == null || b == null || a.Length != b.Length) return false;
+			for (int i = 0; i < a.Length; i++)
+				if (a[i] != b[i]) return false;
+			return true;
+		}
+
+		private static string Revision() =>
+			DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
+	}
+}

--- a/web-snapshot-viewer/WebSnapshotViewer.cs
+++ b/web-snapshot-viewer/WebSnapshotViewer.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace WebOne.SnapshotViewer
+{
+	/// <summary>
+	/// Handles all HTTP requests when --web-snapshot-viewer mode is active.
+	/// Routes requests to the probe page, screenshot handler, strip server, or click handler.
+	/// </summary>
+	class WebSnapshotViewer
+	{
+		private static readonly Dictionary<string, StripSet> Cache = new();
+		private static readonly TimeSpan CacheTTL = TimeSpan.FromMinutes(5);
+
+		private readonly HttpRequest ClientRequest;
+		private readonly HttpResponse ClientResponse;
+		private readonly LogWriter Log;
+
+		public WebSnapshotViewer(HttpRequest request, HttpResponse response, LogWriter log)
+		{
+			ClientRequest = request;
+			ClientResponse = response;
+			Log = log;
+		}
+
+		public void Handle(Uri requestUrl)
+		{
+			if (requestUrl == null)
+			{
+				SendHtml(DimensionProbe.GetPage("about:blank"));
+				return;
+			}
+
+			if (requestUrl.Host.Equals(DimensionProbe.MagicHost, StringComparison.OrdinalIgnoreCase))
+			{
+				switch (requestUrl.AbsolutePath.ToLowerInvariant())
+				{
+					case "/snap":         HandleSnapshot(requestUrl);    break;
+					case "/strip":        HandleStrip(requestUrl);        break;
+					case "/blank-strip":  HandleBlankStrip(requestUrl);  break;
+					case "/click":        HandleClick(requestUrl);        break;
+					case "/scroll-pos":  HandleScrollPos(requestUrl);   break;
+					default:
+						SendHtml("<HTML><BODY><H1>Unknown endpoint.</H1></BODY></HTML>");
+						break;
+				}
+			}
+			else
+			{
+				Log.WriteLine(" [Snapshot] Probe for: {0}", requestUrl);
+				SendHtml(DimensionProbe.GetPage(requestUrl.ToString()));
+			}
+		}
+
+		private void HandleSnapshot(Uri requestUrl)
+		{
+			var qs = HttpUtility.ParseQueryString(requestUrl.Query);
+			string targetUrl = qs["url"];
+			string wStr = qs["w"];
+			string hStr = qs["h"];
+
+			if (string.IsNullOrEmpty(targetUrl) || !int.TryParse(wStr, out int width) || !int.TryParse(hStr, out int height))
+			{
+				SendHtml("<HTML><BODY><H1>Invalid snapshot request.</H1></BODY></HTML>");
+				return;
+			}
+
+			width  = Math.Clamp(width,  320, 3840);
+			height = Math.Clamp(height, 200, 2160);
+
+			string sessionKey = GetSessionKey(targetUrl, width);
+			Log.WriteLine(" [Snapshot] {0} @ {1}px wide", targetUrl, width);
+
+			if (Cache.TryGetValue(sessionKey, out var existing) && DateTime.UtcNow - existing.CreatedAt < CacheTTL)
+			{
+				Log.WriteLine(" [Snapshot] Cache hit.");
+				SendHtml(SnapshotPage.GetShellPage(sessionKey, existing));
+				return;
+			}
+
+			byte[] png;
+			try
+			{
+				png = Task.Run(() => ScreenshotEngine.TakeScreenshot(sessionKey, targetUrl, width, height))
+					.GetAwaiter().GetResult();
+			}
+			catch (Exception ex)
+			{
+				Log.WriteLine(" [Snapshot] Error: {0}", ex.Message);
+				SendHtml(
+					"<HTML><BODY><H1>Screenshot failed</H1>" +
+					"<P>" + HttpUtility.HtmlEncode(targetUrl) + "</P>" +
+					"<PRE>" + HttpUtility.HtmlEncode(ex.Message) + "</PRE>" +
+					"</BODY></HTML>");
+				return;
+			}
+
+			var strips = StripManager.CreateStrips(png, Program.StripHeight, height);
+			Cache[sessionKey] = strips;
+			Log.WriteLine(" [Snapshot] {0} strips created ({1}x{2}px).", strips.Strips.Length, strips.ImageWidth, strips.ImageHeight);
+
+			SendHtml(SnapshotPage.GetShellPage(sessionKey, strips));
+		}
+
+		private void HandleBlankStrip(Uri requestUrl)
+		{
+			var qs = HttpUtility.ParseQueryString(requestUrl.Query);
+			string key = qs["key"];
+
+			if (string.IsNullOrEmpty(key) || !Cache.TryGetValue(key, out var stripSet))
+			{
+				SendHtml("<HTML><BODY><H1>Session not found.</H1></BODY></HTML>");
+				return;
+			}
+
+			byte[] gif = stripSet.BlankStripGif;
+			ClientResponse.StatusCode = 200;
+			ClientResponse.ContentType = "image/gif";
+			ClientResponse.ContentLength64 = gif.Length;
+			ClientResponse.SendHeaders();
+			ClientResponse.OutputStream.Write(gif, 0, gif.Length);
+			ClientResponse.Close();
+		}
+
+		private void HandleStrip(Uri requestUrl)
+		{
+			var qs = HttpUtility.ParseQueryString(requestUrl.Query);
+			string key = qs["key"];
+			string iStr = qs["i"];
+
+			if (string.IsNullOrEmpty(key) ||
+				!int.TryParse(iStr, out int index) ||
+				!Cache.TryGetValue(key, out var stripSet) ||
+				index < 0 || index >= stripSet.Strips.Length)
+			{
+				SendHtml("<HTML><BODY><H1>Strip not found.</H1></BODY></HTML>");
+				return;
+			}
+
+			byte[] jpeg = stripSet.Strips[index].Jpeg;
+			ClientResponse.StatusCode = 200;
+			ClientResponse.ContentType = "image/jpeg";
+			ClientResponse.ContentLength64 = jpeg.Length;
+			ClientResponse.SendHeaders();
+			ClientResponse.OutputStream.Write(jpeg, 0, jpeg.Length);
+			ClientResponse.Close();
+		}
+
+		private void HandleClick(Uri requestUrl)
+		{
+			ClickHandler.Handle(requestUrl, ClientRequest, ClientResponse, Log, Cache);
+		}
+
+		private void HandleScrollPos(Uri requestUrl)
+		{
+			ScrollHandler.HandleScrollPos(requestUrl, ClientResponse, Log, Cache);
+		}
+
+private void SendHtml(string html)
+		{
+			byte[] buffer = Encoding.UTF8.GetBytes(html);
+			ClientResponse.StatusCode = 200;
+			ClientResponse.ContentType = "text/html";
+			ClientResponse.ContentLength64 = buffer.Length;
+			ClientResponse.SendHeaders();
+			ClientResponse.OutputStream.Write(buffer, 0, buffer.Length);
+			ClientResponse.Close();
+		}
+
+		private static string GetSessionKey(string url, int width)
+		{
+			string raw = url + ":" + width;
+			byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(raw));
+			return Convert.ToHexString(hash);
+		}
+	}
+}

--- a/web-snapshot-viewer/test/scroll-test.html
+++ b/web-snapshot-viewer/test/scroll-test.html
@@ -1,0 +1,68 @@
+<HTML>
+<HEAD><TITLE>Scroll Test</TITLE></HEAD>
+<BODY>
+<DIV STYLE="position:fixed;top:10px;left:10px;background:yellow;padding:8px;font-size:16px;font-family:monospace" ID="out">
+y = 0
+</DIV>
+<DIV STYLE="position:fixed;top:40px;left:10px;background:yellow;padding:8px;font-size:16px;font-family:monospace" ID="counter">
+Times of scroll event triggered = 0
+</DIV>
+<DIV STYLE="position:fixed;top:80px;left:10px;background:yellow;padding:8px;font-size:16px;font-family:monospace;cursor:pointer" ONCLICK="checkScroll()">
+Press me to get the y position manually
+</DIV>
+<DIV STYLE="height:5000px">&nbsp;</DIV>
+<SCRIPT LANGUAGE="JavaScript">
+function getScrollY() {
+  if (window.pageYOffset != null) return window.pageYOffset;
+  if (document.documentElement && document.documentElement.scrollTop) return document.documentElement.scrollTop;
+  if (document.body && document.body.scrollTop) return document.body.scrollTop;
+  return 0;
+}
+var timesScroll = 0;
+var lastScrollY = 0;
+
+function updateDisplay(sy) {
+  document.getElementById("counter").innerHTML = "Times of scroll event triggered = " + timesScroll;
+  document.getElementById("out").innerHTML = "y = " + sy;
+}
+
+function checkScroll() {
+  var sy = getScrollY();
+  if (sy != lastScrollY) {
+    lastScrollY = sy;
+    timesScroll++;
+    updateDisplay(sy);
+  }
+}
+
+var usingEvents = false;
+function onScroll() {
+  usingEvents = true;
+  timesScroll++;
+  var sy = getScrollY();
+  lastScrollY = sy;
+  updateDisplay(sy);
+}
+
+if (window.addEventListener) {
+  window.addEventListener("scroll", onScroll, false);
+} else if (window.attachEvent) {
+  window.attachEvent("onscroll", onScroll);
+} else {
+  window.onscroll = onScroll;
+}
+
+// Necesario para Safari 1.0
+setInterval("checkScroll()", 50);
+</SCRIPT>
+</BODY>
+</HTML>
+
+<!-- 
+---------------------------- CONCLUSION ----------------------------
+
+SCROLL EVENT DOESNT WORK, SO IT'S NECESARRY TO USE SETINTERVAL
+SAFARI 1 JUST SUPPORTS USING SETINTERVAL WITH STRING CODE 
+
+-------------------------------------------------------------------
+-->

--- a/web-snapshot-viewer/test/scroll-test.txt
+++ b/web-snapshot-viewer/test/scroll-test.txt
@@ -1,0 +1,6 @@
+Testing:
+
+[√] On click
+[√] Web view position
+[x] OnScroll Event
+[√] Updating using interval


### PR DESCRIPTION
Adds a new exclusive proxy mode that renders modern web pages server-side using Playwright and serves them to old browsers as interactive strip images.

When started with --web-snapshot-viewer, all HTTP requests are routed through WebSnapshotViewer instead of the normal proxy flow. The flow is:

1. Browser requests any URL → proxy returns a lightweight probe page (JS)
2. JS reads viewport dimensions and redirects to snapshot.webone.internal/snap
3. Playwright takes a full-page PNG screenshot at the requested viewport size
4. Screenshot is split into horizontal strips (default 100px height each)
5. Shell page is returned with <IMG> tags — only the first visible strips load
6. As the user scrolls, strips load lazily via JS
7. Clicks are forwarded to Playwright, changed strips are updated in place

- WebSnapshotViewer.cs: HTTP router for all snapshot endpoints
- DimensionProbe.cs: generates the probe page for viewport detection
- ScreenshotEngine.cs: Playwright wrapper (screenshot, scroll, click)
- SnapshotPage.cs: generates the HTML shell page with strip images
- StripManager.cs: splits PNG into strips, hashes each for change detection
- BlankStrip.cs: generates per-session checkerboard GIF placeholder
- ScrollHandler.cs: inline scroll sync JS + /scroll-pos endpoint
- ClickHandler.cs: click overlay JS + /click endpoint
- ClientStripManager.cs: shared JS helpers (sendCmd, updateStrip, reloadPage)
- ARCHITECTURE.md: full system documentation

- --web-snapshot-viewer: enable the mode
- --snapshot-headed: run Playwright browser in visible (headed) mode
- --quality N: JPEG quality 1-100 (default 85)
- --strip-size N: strip height in pixels (default 100)
- --set-min-threads N: thread pool minimum (default 1000)

- JPEG encoded as RGB colorspace to avoid YCbCr->RGB AltiVec crash in Safari 1 on Mac OS X 10.3 PPC (vec_ycc_rgb_convert bug)
- Lazy strip loading: only first viewport/stripHeight+2 strips load initially
- Blank strip placeholder: per-session checkerboard GIF instead of black/white
- Scroll sync via new Image() fire-and-forget (no XHR, Safari 1 compatible)
- Click transport via hidden cmd iframe (Safari 1 compatible AJAX equivalent)
- Thread pool raised to 1000 to avoid starvation with many concurrent connections
- Browser pre-warmed at startup so first request does not wait for Playwright

- Microsoft.Playwright 1.*
- SixLabors.ImageSharp 3.*