### PR TITLE
Dev->Master 0.18.2

### DIFF
--- a/ConfigFile.cs
+++ b/ConfigFile.cs
@@ -233,6 +233,11 @@ namespace WebOne
 		/// </summary>
 		public static bool DontPreferHTTPS = false;
 
+		/// <summary>
+		/// Timespan (seconds) to wait before the connection establishing times out
+		/// </summary>
+		public static int ConnectionTimeout = 100;
+
 
 
 		/// <summary>

--- a/ConfigFileLoader.cs
+++ b/ConfigFileLoader.cs
@@ -313,6 +313,10 @@ namespace WebOne
 								case "DontPreferHTTPS":
 									ConfigFile.DontPreferHTTPS = ToBoolean(Option.Value);
 									break;
+								case "ConnectionTimeout":
+									if (!int.TryParse(Option.Value, out ConfigFile.ConnectionTimeout))
+										Log.WriteLine(true, false, "Warning: Incorrect ConnectionTimeout '{0}'.", Option.Value);
+									break;
 								default:
 									Log.WriteLine(true, false, "Warning: Unknown server option {0} in {1}.", Option.Key, Option.Location);
 									break;

--- a/ConfigFileLoader.cs
+++ b/ConfigFileLoader.cs
@@ -280,7 +280,9 @@ namespace WebOne
 									ConfigFile.MultipleHttp2Connections = ToBoolean(Option.Value);
 									break;
 								case "RemoteHttpVersion":
-									if (System.Text.RegularExpressions.Regex.IsMatch(Option.Value, @"([=><a])[u0-3][t\.][o0-9]"))
+									if (System.Text.RegularExpressions.Regex.IsMatch(Option.Value, @"[\d][\.][\d]"))
+									{ ConfigFile.RemoteHttpVersion = "=" + Option.Value; }
+									else if (System.Text.RegularExpressions.Regex.IsMatch(Option.Value, @"([=><a])[u0-3][t\.][o0-9]"))
 									{ ConfigFile.RemoteHttpVersion = Option.Value; }
 									else
 									{ Log.WriteLine(true, false, "Warning: Incorrect RemoteHttpVersion '{0}'.", Option.Value); }

--- a/HttpTransit.cs
+++ b/HttpTransit.cs
@@ -276,6 +276,7 @@ namespace WebOne
 				//if (LocalMode && ClientRequest.Headers["User-Agent"] != null && ClientRequest.Headers["User-Agent"].Contains("WebOne"))
 				if (ClientRequest.Headers["User-Agent"] != null && ClientRequest.Headers["User-Agent"].Contains("WebOne"))
 				{
+					if (SendInternalContent("Err-LoopRequest.htm", "", 403)) return;
 					SendError(403, "Loop requests are probhited.");
 					return;
 				}

--- a/Program.cs
+++ b/Program.cs
@@ -79,7 +79,7 @@ namespace WebOne
 			Assembly.GetExecutingAssembly().GetName().Version.Major + "." +
 			Assembly.GetExecutingAssembly().GetName().Version.Minor + "." +
 			Assembly.GetExecutingAssembly().GetName().Version.Build
-			//+ "-pre"
+			+ "-pre"
 			);
 			Variables.Add("WOSystem", RuntimeInformation.OSDescription);
 

--- a/Program.cs
+++ b/Program.cs
@@ -128,6 +128,7 @@ namespace WebOne
 			}
 
 			//initialize system HTTP socket message handler for static HttpClient used by HttpOperation class instances
+			HTTPHandler.ConnectTimeout = new(0, 0, ConfigFile.ConnectionTimeout);
 			HTTPHandler.SslOptions.RemoteCertificateValidationCallback = CheckServerCertificate;
 			HTTPHandler.AllowAutoRedirect = false;
 			HTTPHandler.AutomaticDecompression = ConfigFile.AllowHttpCompression ? DecompressionMethods.All : DecompressionMethods.None;

--- a/Program.cs
+++ b/Program.cs
@@ -76,10 +76,9 @@ namespace WebOne
 		static void Main(string[] args)
 		{
 			Variables.Add("WOVer",
-			Assembly.GetExecutingAssembly().GetName().Version.Major + "." +
-			Assembly.GetExecutingAssembly().GetName().Version.Minor + "." +
-			Assembly.GetExecutingAssembly().GetName().Version.Build
-			+ "-pre"
+			Assembly.GetExecutingAssembly()?
+			.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+			.InformationalVersion
 			);
 			Variables.Add("WOSystem", RuntimeInformation.OSDescription);
 

--- a/WebArchiveRequest.cs
+++ b/WebArchiveRequest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.IO;
 
 namespace WebOne
 {
@@ -24,22 +24,26 @@ namespace WebOne
 			string CdxUrl = string.Format(
 			"https://web.archive.org/cdx/search/cdx?fl={0}&url={1}",
 			"timestamp,original,statuscode", //fields: ["urlkey","timestamp","original","mimetype","statuscode","digest","length"]
-		 	Uri.EscapeDataString(URL));
+			Uri.EscapeDataString(URL));
 			const int CdxFieldsCount = 3;
 
 			//send request to CDX server
-			var CdxResponse = new HttpClient().Send(new HttpRequestMessage(HttpMethod.Get,new Uri(CdxUrl)));
+			var CdxRequestMessage = new HttpRequestMessage(HttpMethod.Get, new Uri(CdxUrl));
+			CdxRequestMessage.Headers.Add("User-Agent", "WebOne/" + Program.Variables["WOVer"]);
+			var CdxResponse = new HttpClient().Send(CdxRequestMessage);
 			if (!CdxResponse.IsSuccessStatusCode) throw new Exception("Unsuccessful Web Archive request: " + CdxResponse.ReasonPhrase ?? " without reason");
 			string[] CdxBody = new StreamReader(CdxResponse.Content.ReadAsStream()).ReadToEnd().TrimEnd().Split('\n');
 
-			if(CdxBody.Length == 0){
+			if (CdxBody.Length == 0)
+			{
 				//not archived
 				Archived = false;
 				ArchivedURL = "";
 				return;
 			}
 
-			if(CdxBody[0] == string.Empty){
+			if (CdxBody[0] == string.Empty)
+			{
 				//not archived too
 				Archived = false;
 				ArchivedURL = "";
@@ -52,7 +56,7 @@ namespace WebOne
 			{
 				string[] Fields = CdxEntry.Split(" ");
 				if (Fields.Count() != CdxFieldsCount) continue;
-				if(ConfigFile.ArchiveDateLimit > 0)
+				if (ConfigFile.ArchiveDateLimit > 0)
 				{
 					long.TryParse(Fields[0], out long Timestamp);
 					if (Timestamp > ConfigFile.ArchiveDateLimit * (Math.Pow(10, 6))) continue;
@@ -62,7 +66,8 @@ namespace WebOne
 			if (LastCdxEntry == "") LastCdxEntry = CdxBody[^1];
 
 			string[] ResultFields = LastCdxEntry.Split(" ");
-			if(ResultFields.Count() != CdxFieldsCount){
+			if (ResultFields.Count() != CdxFieldsCount)
+			{
 				//bad CDX syntax
 				Archived = false;
 				ArchivedURL = "";
@@ -71,16 +76,16 @@ namespace WebOne
 
 			Archived = true;
 			ArchivedURL = string.Format("http://web.archive.org/web/{0}/{1}", ResultFields[0], ResultFields[1]);
-	}
+		}
 
-	/// <summary>
-	/// Is the requested URL archived by Wayback Machine
-	/// </summary>
-	public bool Archived { get; private set; }
+		/// <summary>
+		/// Is the requested URL archived by Wayback Machine
+		/// </summary>
+		public bool Archived { get; private set; }
 
-	/// <summary>
-	/// Address of archived copy of requested URL
-	/// </summary>
-	public string ArchivedURL { get; private set; }
+		/// <summary>
+		/// Address of archived copy of requested URL
+		/// </summary>
+		public string ArchivedURL { get; private set; }
 	}
 }

--- a/WebOne.csproj
+++ b/WebOne.csproj
@@ -8,6 +8,7 @@
 		<Version>0.18.2</Version>
 		<VersionSuffix>-pre</VersionSuffix> <!--<VersionSuffix>-pre</VersionSuffix>-->
 		<PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
+		<InformationalVersion>$(PackageVersion)</InformationalVersion>
 		<Company>World</Company>
 		<Product>WebOne HTTP Proxy Server</Product>
 		<Description>HTTP 1.x proxy that makes old web browsers usable again in the Web 2.0 world.</Description>
@@ -43,6 +44,7 @@
 		<CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
 		<DebugType>None</DebugType>
 		<DebugSymbols>false</DebugSymbols>
+		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(RuntimeIdentifier)!='linux-armv6'">

--- a/WebOne.csproj
+++ b/WebOne.csproj
@@ -5,8 +5,8 @@
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net8.0</TargetFramework>
 		<Authors>Alexander Tauenis</Authors>
-		<Version>0.18.1</Version>
-		<VersionSuffix></VersionSuffix> <!--<VersionSuffix>-pre</VersionSuffix>-->
+		<Version>0.18.2</Version>
+		<VersionSuffix>-pre</VersionSuffix> <!--<VersionSuffix>-pre</VersionSuffix>-->
 		<PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
 		<Company>World</Company>
 		<Product>WebOne HTTP Proxy Server</Product>

--- a/WebOne.csproj
+++ b/WebOne.csproj
@@ -6,7 +6,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<Authors>Alexander Tauenis</Authors>
 		<Version>0.18.2</Version>
-		<VersionSuffix>-pre</VersionSuffix> <!--<VersionSuffix>-pre</VersionSuffix>-->
+		<VersionSuffix></VersionSuffix> <!--<VersionSuffix>-pre</VersionSuffix>-->
 		<PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
 		<InformationalVersion>$(PackageVersion)</InformationalVersion>
 		<Company>World</Company>

--- a/WebVideoPlayer.cs
+++ b/WebVideoPlayer.cs
@@ -17,139 +17,23 @@ namespace WebOne
 			Page.ShowFooter = false;
 			Page.HtmlHeaders = "<style type='text/css'>html, body { border-style: none; } </style>";
 
-			string VideoUrl = Program.ProcessUriMasks("/!webvideo/?");
+			string VideoUrl = "/!webvideo/?";
 			foreach (string Par in Parameters.AllKeys)
 			{ if (Par != "type") VideoUrl += Par + "=" + HttpUtility.UrlEncode(Parameters[Par]) + "&"; }
-
-			// Initial page & iframe status
-			string SampleUrl = Parameters["url"] ?? "https://www.youtube.com/watch?v=XXXXXXX";
-			string PreferPage = "intro";
-			if (Parameters["gui"] == "1")
-			{
-				Parameters["type"] = null;
-				if (Parameters["prefer"] != null) PreferPage = Parameters["prefer"] + "&url=" + SampleUrl;
-			}
 
 			if (!ConfigFile.WebVideoOptions.ContainsKey("Enable") || !Program.ToBoolean(ConfigFile.WebVideoOptions["Enable"] ?? "yes"))
 			{
 				Page.Content = "It's disabled.";
-				Page.HttpHeaders.Add("Refresh", "0;url=/norovp.htm");
+				Page.HttpStatusCode = 302;
+				Page.HttpHeaders.Add("Location", "/norovp.htm");
 				return;
 			}
 
-			switch (Parameters["type"])
+			string PlayerType = Parameters["type"];
+			if (string.IsNullOrWhiteSpace(Parameters["type"])) PlayerType = "splash";
+
+			switch (PlayerType)
 			{
-				case "":
-				case null:
-					Page.Content = "<div style=\"background-color: black; color: white; padding: 3em;\"><p align=\"center\">";
-					Page.Content += "<a href=\"/rovp.htm\"><img src=\"/rovp.gif\" alt=\"Click here to open Retro Online Video Player.\" border=\"0\"></a>";
-					Page.Content += "<br><h1 align=\"center\">Retro Online Video Player</h1>";
-					Page.Content += "</p></div>";
-					Page.HttpHeaders.Add("Refresh", "5;url=/rovp.htm");
-					break;
-				case "intro":
-					Page.Content = "<p align='center'><big>Use the toolbar above to watch a video.</big></p>";
-					Page.Content += "<noscript><p align='center'>If you have troubles with playback, read help page (&quot;?&quot; at the top).</p></noscript>";
-					Page.AddCss = false;
-					Page.Title = "Video player - INTRO";
-					break;
-				case "embed":
-					// [Embed] Universal - plugin
-					string EmbHtml = "<embed id='MediaPlayer' " +
-					"showcontrols='true' showpositioncontrols='true' showstatusbar='tue' showgotobar='true'" +
-					"src='" + VideoUrl + "' autostart='true' style='width: 100%; height: 100%;' />";
-					Page.Content = EmbHtml;
-					Page.AddCss = false;
-					Page.Title = "Video player - Universal";
-					break;
-				case "embedwm":
-					// [WMP] Windows Media Player - plugin
-					string WMP64html = "<embed id='MediaPlayer' type='application/x-mplayer2'" +
-					"pluginspage='http://microsoft.com/windows/mediaplayer/en/download/'" +
-					"showcontrols='true' showpositioncontrols='true' showstatusbar='tue' showgotobar='true'" +
-					"src='" + VideoUrl + "' autostart='true' style='width: 100%; height: 100%;' />";
-					Page.Content = WMP64html;
-					Page.AddCss = false;
-					Page.Title = "Video player - WMP";
-					break;
-				case "embedvlc":
-					// [VLC] VLC Mediaplayer - plugin
-					string VlcHtml = "<embed id='MediaPlayer' type='application/x-vlc-plugin'" +
-					"codebase='http://download.videolan.org/pub/videolan/vlc/last/win32/axvlc.cab'" +
-					"pluginspage='http://www.videolan.org'" +
-					"showcontrols='true' showpositioncontrols='true' showstatusbar='tue' showgotobar='true' autoplay='yes'" +
-					"src='" + VideoUrl + "' autostart='true' style='width: 100%; height: 100%;' />";
-					Page.Content = VlcHtml;
-					Page.AddCss = false;
-					Page.Title = "Video player - VLC";
-					break;
-				case "objectns":
-					// [NetShow] NetShow Player Control, Windows Media Player 5/6 Control - ActiveX
-					// Docs: https://web.archive.org/web/20010124080600/http://msdn.microsoft.com/library/psdk/wm_media/wmplay/mmp_sdk/
-					// Docs: https://web.archive.org/web/19990117015933/http://www.microsoft.com/devonly/tech/amov1doc/amsdk008.htm
-					/*
-					 * Download: http://www.microsoft.com/netshow/download/player.htm
-					 * CODEBASE='http://www.microsoft.com/netshow/download/en/nsasfinf.cab#Version=2,0,0,912'  - NS 2.0
-					 * CODEBASE='http://www.microsoft.com/netshow/download/en/nsmp2inf.cab#Version=5,1,51,415' - NS 3.0 aka WMP 5.2 Beta
-					 * CODEBASE='http://activex.microsoft.com/activex/controls/mplayer/en/nsmp2inf.cab#Version=6,4,7,1112' - WMP 6.4 RTM
-					 */
-					string NSActiveXhtml = "<center><object ID='MediaPlayer' style='width: 100%; height: 100%;' " +
-					"CLASSID='CLSID:2179C5D3-EBFF-11CF-B6FD-00AA00B4E220' " +
-					"codebase='http://www.microsoft.com/netshow/download/en/nsasfinf.cab#Version=2,0,0,912'" +
-					"standby='Loading Microsoft NetShow Player components...'>" +
-					"<param name='FileName' value='" + VideoUrl + "'>" +
-					"<param name='ControlType' value='2'>" +
-					"<param name='EnableContextMenu' value='true'>" +
-					"<param name='AnimationAtStart' value='true'>" +
-					"<param name='TransparentAtStart' value='false'>" +
-					"<param name='AutoStart' value='true'>" +
-					"This mode is working only with Microsoft Internet Explorer 3 (or newer) and NetShow Player 2.0." +
-					"</object></center>";
-					Page.Content = NSActiveXhtml;
-					Page.AddCss = false;
-					Page.Title = "Video player - NetShow ActiveX";
-					break;
-				case "objectwm":
-					// [WinMedia] Windows Media Player 7.0 Control - ActiveX
-					// Download: http://microsoft.com/windows/mediaplayer/en/download/
-					// Docs: https://learn.microsoft.com/en-us/previous-versions/windows/desktop/wmp/detailed-object-model-comparison
-					string WMPActiveXhtml = "<center><object ID='MediaPlayer' style='width: 100%; height: 100%;' " +
-					"CLASSID='CLSID:6BF52A52-394A-11d3-B153-00C04F79FAA6' " +
-					"codebase='http://activex.microsoft.com/activex/controls/mplayer/en/nsmp2inf.cab#Version=6,4,7,1112'" +
-					"standby='Loading Microsoft Windows Media Player components...'>" +
-					"<param name='URL' value='" + VideoUrl + "'>" +
-					"<param name='ShowControls' value='true'>" +
-					"<param name='ShowDisplay' value='true'>" +
-					"<param name='ShowStatusBar' value='true'>" +
-					"<param name='ShowPositionControls' value='true'>" +
-					"<param name='ShowGoToBar' value='true'>" +
-					"<param name='Controls' value='true'>" +
-					"<param name='AutoSize' value='true'>" +
-					"<param name='AutoStart' value='true'>" +
-					"Try another player type, as Windows Media Player Control 7.0 (or newer) is unavailable." +
-					"</object></center>";
-					Page.Content = WMPActiveXhtml;
-					Page.AddCss = false;
-					Page.Title = "Video player - WMP ActiveX";
-					break;
-				case "html5":
-					// HTML5 VIDEO tag
-					Page.Content = "<center><video id='MediaPlayer' src='" + VideoUrl + "' controls='yes' autoplay='yes' style='width: 100%; height: 100%;'>"
-					+ "Try another player type, as HTML5 is not supported.</video></center>";
-					Page.AddCss = false;
-					//idea: made multi-source code with hard-coded containers (ogg, webm, etc)
-					Page.Title = "Video player - HTML5";
-					break;
-				case "dynimg":
-					// Dynamic Image - IE only 
-					// (http://www.jmcgowan.com/aviweb.html)
-					// also: https://web.archive.org/web/19990117015933/http://www.microsoft.com/devonly/tech/amov1doc/amsdk008.htm
-					// optimized for MPEG format & codec
-					string PlaceholderUrl = "/nodynsrc.gif";
-					Page.Content = "<center><IMG DYNSRC='" + VideoUrl + "' CONTROLS START='FILEOPEN' SRC='" + PlaceholderUrl + "'></center>";
-					Page.AddCss = false;
-					Page.Title = "Video player - Dynamic Image";
-					break;
 				case "link":
 					// Link only
 					Page.Content = "<center><big><a href='" + VideoUrl + "'>Download the video</a></big></center>";
@@ -164,12 +48,51 @@ namespace WebOne
 					Page.AddCss = false;
 					Page.Title = "Video player - FILE REDIRECT";
 					break;
-				default:
-					Page.Content = "Unknown player type.";
-					Page.AddCss = false;
-					Page.Title = "Video player - ERROR";
-					break;
 			}
+
+			Page.HttpStatusCode = 302;
+			Page.HttpHeaders.Add("Location", "/rovp-" + PlayerType + ".htm");
+			if (VideoUrl != "/!webvideo/?") Page.HttpHeaders["Location"] += "?VideoUrl=" + HttpUtility.UrlEncode(VideoUrl);
+			return;
+
+			/* Notes about HTML-based players.
+			 * 
+			 * Null or empty:
+			 *	Splash screen.
+			 * "intro"
+			 *	Intro - Help message.
+			 * "embed" 
+			 *	[Embed] Universal - plugin
+			 * "embedwm"
+			 *	[WMP] Windows Media Player - plugin
+			 * "embedvlc"
+			 *	[VLC] VLC Mediaplayer - plugin
+			 * "objectns"
+			 *	[NetShow] NetShow Player Control, Windows Media Player 5/6 Control - ActiveX
+			 *	Docs: https://web.archive.org/web/20010124080600/http://msdn.microsoft.com/library/psdk/wm_media/wmplay/mmp_sdk/
+			 *	Docs: https://web.archive.org/web/19990117015933/http://www.microsoft.com/devonly/tech/amov1doc/amsdk008.htm
+			 *	Download: http://www.microsoft.com/netshow/download/player.htm
+			 *	CODEBASE='http://www.microsoft.com/netshow/download/en/nsasfinf.cab#Version=2,0,0,912'  - NS 2.0
+			 *	CODEBASE='http://www.microsoft.com/netshow/download/en/nsmp2inf.cab#Version=5,1,51,415' - NS 3.0 aka WMP 5.2 Beta
+			 *	CODEBASE='http://activex.microsoft.com/activex/controls/mplayer/en/nsmp2inf.cab#Version=6,4,7,1112' - WMP 6.4 RTM
+			 * "objectwm"
+			 *	[WinMedia] Windows Media Player 7.0 Control - ActiveX
+			 *	Download: http://microsoft.com/windows/mediaplayer/en/download/
+			 *	Docs: https://learn.microsoft.com/en-us/previous-versions/windows/desktop/wmp/detailed-object-model-comparison
+			 * "html5"
+			 *	HTML5 VIDEO tag
+			 * "dynimg"
+			 *	Dynamic Image - IE only 
+			 *	(http://www.jmcgowan.com/aviweb.html)
+			 *	https://web.archive.org/web/19990117015933/http://www.microsoft.com/devonly/tech/amov1doc/amsdk008.htm
+			 *	optimized for MPEG format & codec
+			 * "link"
+			 *	Link only
+			 * "file"
+			 *	Redirect to file only
+			 * Other
+			 *	Error message
+			*/
 		}
 	}
 }

--- a/WebVideoPlayer.cs
+++ b/WebVideoPlayer.cs
@@ -53,6 +53,7 @@ namespace WebOne
 			Page.HttpStatusCode = 302;
 			Page.HttpHeaders.Add("Location", "/rovp-" + PlayerType + ".htm");
 			if (VideoUrl != "/!webvideo/?") Page.HttpHeaders["Location"] += "?VideoUrl=" + HttpUtility.UrlEncode(VideoUrl);
+			if (PlayerType == "html5") Page.HttpHeaders["Location"] += "&JsonUrl=" + HttpUtility.UrlEncode("/!webvideo/?&dump-json=&url=" + Parameters["url"] + "&no-warnings=&quiet=");
 			return;
 
 			/* Notes about HTML-based players.

--- a/Win32-full/yt-dlp.txt
+++ b/Win32-full/yt-dlp.txt
@@ -1,4 +1,4 @@
-2025.12.08
+2026.03.17
 Usage: yt-dlp [OPTIONS] URL [URL...]
 
 Options:
@@ -103,7 +103,7 @@ Options:
                                     (default)
     --live-from-start               Download livestreams from the start.
                                     Currently experimental and only supported
-                                    for YouTube and Twitch
+                                    for YouTube, Twitch, and TVer
     --no-live-from-start            Download livestreams from the current time
                                     (default)
     --wait-for-video MIN[-MAX]      Wait for scheduled streams to become
@@ -562,6 +562,8 @@ Options:
                                     for more details
     -S, --format-sort SORTORDER     Sort the formats by the fields given, see
                                     "Sorting Formats" for more details
+    --format-sort-reset             Disregard previous user specified sort order
+                                    and reset to the default
     --format-sort-force             Force user specified sort order to have
                                     precedence over all fields, see "Sorting
                                     Formats" for more details (Alias: --S-force)

--- a/escargot.conf
+++ b/escargot.conf
@@ -12,7 +12,7 @@ AddInternalRedirect=https://msnmsgr.escargot.chat/$1
 ; MSN 4.7-7.0	Login
 [Edit:^http://nexus.passport.com/(.*)]
 AddInternalRedirect=https://msnmsgr.escargot.chat/$1
-AddResponseHeader=PassportURLs: DALogin=https://ds.escargot.nina.chat/login,DAReg=http://%Proxy%/msnreg.htm
+AddResponseHeader=PassportURLs: DALogin=https://ds.escargot.nina.chat/login,DAReg=http://%Proxy%/msnreg.htm,Properties=https://account.escargot.chat/,Privacy=https://escargot.chat/legal/privacy/
 
 ; MSN 4.7	Login, step 2
 [Edit:http://login.live.com/login2.srf]
@@ -26,6 +26,10 @@ AddInternalRedirect=https://msnmsgr.escargot.chat/$1
 [Edit:^http://login.live.com/(.*)]
 IgnoreUrl=login2.srf
 AddInternalRedirect=https://msnmsgr.escargot.chat/$1
+
+; MSN		login fix
+[Edit:^http://ds.escargot.nina.chat/loginDALogin=https://ds.escargot.nina.chat/login]
+AddInternalRedirect=https://ds.escargot.nina.chat/login
 
 ; PocketMSN 5	Login
 [Edit:^http://[a-zA-Z0-9\.]*.mobile.msn.com/(.*)]
@@ -98,6 +102,14 @@ AddRedirect=https://web.archive.org/web/20061022190527if_/http://feedback.live.c
 ; MSN Home Page
 [Edit:^http://g.msn.com/5meen_us/103]
 AddRedirect=https://escargot.chat/
+
+; Service Status
+[Edit:^http://g.msn.com/5meen_us/109]
+AddRedirect=https://escargot.chat/stats/
+
+; MSN Users Directory
+[Edit:^http://g.msn.com/5meen_us/125]
+AddRedirect=https://escargot.chat/contacts/
 
 ; Windows XP .NET Passport	Sign up wizard
 [Edit:^http://register.passport.com/defaultwiz.asp]

--- a/escargot.conf
+++ b/escargot.conf
@@ -12,6 +12,7 @@ AddInternalRedirect=https://msnmsgr.escargot.chat/$1
 ; MSN 4.7-7.0	Login
 [Edit:^http://nexus.passport.com/(.*)]
 AddInternalRedirect=https://msnmsgr.escargot.chat/$1
+AddResponseHeader=PassportURLs: DALogin=https://ds.escargot.nina.chat/login,DAReg=http://%Proxy%/msnreg.htm
 
 ; MSN 4.7	Login, step 2
 [Edit:http://login.live.com/login2.srf]
@@ -98,9 +99,37 @@ AddRedirect=https://web.archive.org/web/20061022190527if_/http://feedback.live.c
 [Edit:^http://g.msn.com/5meen_us/103]
 AddRedirect=https://escargot.chat/
 
-; Edit Windows XP .NET Passport
+; Windows XP .NET Passport	Sign up wizard
+[Edit:^http://register.passport.com/defaultwiz.asp]
+AddRedirect=http://%Proxy%/msnreg.htm
+
+; Windows XP .NET Passport	Sign up wizard (WL)
+[Edit:^https://login.live.com/err.srf]
+AddRedirect=http://%Proxy%/msnreg.htm
+
+; Windows XP .NET Passport	Edit profile
+[Edit:^http://memberservices.passport.com/ppsecure/MSRV_EditProfile.asp]
+AddRedirect=https://escargot.chat/account/
+
+; Windows XP .NET Passport	Edit profile (WL)
 [Edit:^http://account.live.com/EditProf.aspx]
 AddRedirect=https://escargot.chat/account/
+
+; Windows XP .NET Passport	Privacy policy
+[Edit:^http://www.passport.com/consumer/privacypolicy.asp]
+AddRedirect=https://escargot.chat/legal/privacy/
+
+; Windows XP .NET Passport	Privacy policy (WL)
+[Edit:^http://login.live.com/gls.srf\?urlID=MSNPrivacyStatement]
+AddRedirect=https://escargot.chat/legal/privacy/
+
+; Windows XP .NET Passport	Help
+[Edit:^http://memberservices.passport.com/UI/MSRV_UI_Help.asp]
+AddRedirect=https://escargot.chat/legal/rules/
+
+; Windows XP .NET Passport	Help (WL)
+[Edit:^http://account.live.com/.*dc=PPRDR_Help]
+AddRedirect=https://escargot.chat/legal/rules/
 
 ; Sign Up for a new .NET Passport
 [Edit:^http://g.msn.com/5meen_us/105]

--- a/html/Err-LoopRequest.htm
+++ b/html/Err-LoopRequest.htm
@@ -1,0 +1,12 @@
+﻿<html>
+<title>Loop requests are probhited</title>
+<meta charset="utf-8"/>
+<link href="http://%ServerName%/webone.css" rel="stylesheet" />
+<body>
+<P><BIG>Seems that you have looped connection.</BIG></P>
+<P>This may be caused by incorrect WebOne or operating system configuration.</P>
+<P>Set <B>UpperProxy</B> to <B>no</B> in configuration file to enable WebOne direct connection to the Internet.</P>
+<P>Make sure that only the client browser is accessing Internet via proxy, and the proxy server have a true direct connection. Note that WebOne is using system settings to access Internet. Some browsers (Internet Explorer, Safari, all Chromium-based) are using same settings as the OS where they are started.</P>
+<hr>WebOne Proxy Server %WOVer% <br>on %WOSystem%
+</body>
+</html>

--- a/html/msnreg.htm
+++ b/html/msnreg.htm
@@ -1,0 +1,53 @@
+<html>
+    <head>
+        <script language="JavaScript">
+            function window.onload()
+            {
+                window.external.SetWizardButtons(1, 1, 0);
+                window.external.SetHeaderText("Your proxy server suports .NET Passport authentication", "Use Escargot for MSN Messenger");
+            }
+
+            function window.onback()
+            {
+                window.external.FinalBack();
+            }
+            function window.onnext()
+            {
+                window.open("https://escargot.chat/");
+                window.external.FinalNext();
+            }
+        </script>
+        <base href="http://legacy.escargot.chat/" />
+        <link rel="stylesheet" href="/css/site.css?v=2">
+    </head>
+<body>
+<table class="w-100" width="100%">
+    <tr>
+        <td>
+            <h1 class="font">
+                <img alt="Escargot logo" class="escargot" src="/gif/favicon.gif">
+                <span>Escargot </span>
+                <font color="#808080" class="legacy">Member Services</font>
+            </h1>
+        </td>
+    </tr>
+</table>
+<table class="w-100" width="100%">
+    <tr>
+        <td>
+            <p class="font">
+                Escargot is a new service that makes old versions of MSN Messenger and Windows Live Messenger work again.
+                <br><br>
+                What began as a simple server developed by a lone programmer, the project has now grown through leaps and
+                bounds, has a dedicated team, and is now focused on a total revival of the MSN Messenger and Windows Live experience.
+                <br><br>
+                <a href="/connect/" target="_blank">Learn how to get started</a>
+            </p>
+        </td>
+        <td width="220">
+            <img align="right" alt="Escargot showcase" width="200" src="/gif/escargot_showcase.gif"/>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/html/msnreg.htm
+++ b/html/msnreg.htm
@@ -1,53 +1,42 @@
 <html>
-    <head>
-        <script language="JavaScript">
-            function window.onload()
-            {
-                window.external.SetWizardButtons(1, 1, 0);
-                window.external.SetHeaderText("Your proxy server suports .NET Passport authentication", "Use Escargot for MSN Messenger");
-            }
 
-            function window.onback()
-            {
-                window.external.FinalBack();
-            }
-            function window.onnext()
-            {
-                window.open("https://escargot.chat/");
-                window.external.FinalNext();
-            }
-        </script>
-        <base href="http://legacy.escargot.chat/" />
-        <link rel="stylesheet" href="/css/site.css?v=2">
-    </head>
-<body>
-<table class="w-100" width="100%">
-    <tr>
-        <td>
-            <h1 class="font">
-                <img alt="Escargot logo" class="escargot" src="/gif/favicon.gif">
-                <span>Escargot </span>
-                <font color="#808080" class="legacy">Member Services</font>
-            </h1>
-        </td>
-    </tr>
-</table>
-<table class="w-100" width="100%">
-    <tr>
-        <td>
-            <p class="font">
-                Escargot is a new service that makes old versions of MSN Messenger and Windows Live Messenger work again.
-                <br><br>
-                What began as a simple server developed by a lone programmer, the project has now grown through leaps and
-                bounds, has a dedicated team, and is now focused on a total revival of the MSN Messenger and Windows Live experience.
-                <br><br>
-                <a href="/connect/" target="_blank">Learn how to get started</a>
-            </p>
-        </td>
-        <td width="220">
-            <img align="right" alt="Escargot showcase" width="200" src="/gif/escargot_showcase.gif"/>
-        </td>
-    </tr>
-</table>
-</body>
+<head>
+<script language="JavaScript">
+    function window.onload()
+    {
+        window.external.SetWizardButtons(1, 1, 0);
+        window.external.SetHeaderText("Your proxy server brings back .NET Passport authentication", "Use Escargot for MSN Messenger");
+    }
+
+    function window.onback()
+    {
+        window.external.FinalBack();
+    }
+    function window.onnext()
+    {
+        window.open("https://escargot.chat/");
+        window.external.FinalNext();
+    }
+</script>
+<title>Passport is live again!</title>
+</head>
+
+<body bgcolor="threedface">
+<font size="2"
+face="Tahoma">
+<h1 id="l1" class="font"><img src="http://legacy.escargot.chat/gif/favicon.gif" 
+alt="Escargot logo" width="32" height="32" class="escargot"> <span>Escargot </span> 
+<font color="#808080"><font class="legacy">Account</font></font>
+        </h1>
+
+<p id="l3"><font size="2" face="Tahoma">Escargot is a new service
+that makes old versions of MSN Messenger and Windows Live
+Messenger work again.</font></p>
+
+<p id="l4"><font size="2" face="Tahoma">You can use your Escargot
+account as .NET Passport in Windows Messenger.</font></p>
+
+<p id="l5"><a href="http://legacy.escargot.chat/connect/" target="_blank"><font
+size="2" face="Tahoma">Learn how to get started</font></a></p>
+</font></body>
 </html>

--- a/html/rovp-dynimg.htm
+++ b/html/rovp-dynimg.htm
@@ -1,9 +1,8 @@
 ﻿<html>
 <title>Video player - Dynamic Image</title>
 <meta charset="utf-8"/>
-<style type='text/css'>html, body { border-style: none; } </style><body>
-<h1></h1>
-
+<style type='text/css'>html, body { border-style: none; } </style>
+<body>
 <center><IMG DYNSRC='%VideoUrl%' CONTROLS START='FILEOPEN' SRC='/nodynsrc.gif'></center>
 </body>
 </html>

--- a/html/rovp-dynimg.htm
+++ b/html/rovp-dynimg.htm
@@ -1,0 +1,9 @@
+﻿<html>
+<title>Video player - Dynamic Image</title>
+<meta charset="utf-8"/>
+<style type='text/css'>html, body { border-style: none; } </style><body>
+<h1></h1>
+
+<center><IMG DYNSRC='%VideoUrl%' CONTROLS START='FILEOPEN' SRC='/nodynsrc.gif'></center>
+</body>
+</html>

--- a/html/rovp-embed.htm
+++ b/html/rovp-embed.htm
@@ -1,0 +1,7 @@
+﻿<html><head><title>Video player - Universal</title>
+<meta charset="utf-8">
+<style type="text/css">html, body { border-style: none; } </style></head><body>
+<h1></h1>
+
+<embed id="MediaPlayer" showcontrols="true" showpositioncontrols="true" showstatusbar="tue" showgotobar="true" src="%VideoUrl%" autostart="true" style="width: 100%; height: 100%;">
+</body></html>

--- a/html/rovp-embed.htm
+++ b/html/rovp-embed.htm
@@ -1,7 +1,10 @@
-﻿<html><head><title>Video player - Universal</title>
+﻿<html>
+<head>
+<title>Video player - Universal</title>
 <meta charset="utf-8">
-<style type="text/css">html, body { border-style: none; } </style></head><body>
-<h1></h1>
-
+<style type="text/css">html, body { border-style: none; } </style>
+</head>
+<body>
 <embed id="MediaPlayer" showcontrols="true" showpositioncontrols="true" showstatusbar="tue" showgotobar="true" src="%VideoUrl%" autostart="true" style="width: 100%; height: 100%;">
-</body></html>
+</body>
+</html>

--- a/html/rovp-embedvlc.htm
+++ b/html/rovp-embedvlc.htm
@@ -1,0 +1,9 @@
+﻿<html>
+<title>Video player - VLC</title>
+<meta charset="utf-8"/>
+<style type='text/css'>html, body { border-style: none; } </style><body>
+<h1></h1>
+
+<embed id='MediaPlayer' type='application/x-vlc-plugin'codebase='http://download.videolan.org/pub/videolan/vlc/last/win32/axvlc.cab'pluginspage='http://www.videolan.org'showcontrols='true' showpositioncontrols='true' showstatusbar='tue' showgotobar='true' autoplay='yes'src='%VideoUrl%' autostart='true' style='width: 100%; height: 100%;' />
+</body>
+</html>

--- a/html/rovp-embedvlc.htm
+++ b/html/rovp-embedvlc.htm
@@ -1,9 +1,8 @@
 ﻿<html>
 <title>Video player - VLC</title>
 <meta charset="utf-8"/>
-<style type='text/css'>html, body { border-style: none; } </style><body>
-<h1></h1>
-
-<embed id='MediaPlayer' type='application/x-vlc-plugin'codebase='http://download.videolan.org/pub/videolan/vlc/last/win32/axvlc.cab'pluginspage='http://www.videolan.org'showcontrols='true' showpositioncontrols='true' showstatusbar='tue' showgotobar='true' autoplay='yes'src='%VideoUrl%' autostart='true' style='width: 100%; height: 100%;' />
+<style type='text/css'>html, body { border-style: none; } </style>
+<body>
+<embed id='MediaPlayer' type='application/x-vlc-plugin'codebase='http://download.videolan.org/pub/videolan/vlc/last/win32/axvlc.cab' pluginspage='http://www.videolan.org' showcontrols='true' showpositioncontrols='true' showstatusbar='tue' showgotobar='true' autoplay='yes' src='%VideoUrl%' autostart='true' style='width: 100%; height: 100%;' />
 </body>
 </html>

--- a/html/rovp-embedwm.htm
+++ b/html/rovp-embedwm.htm
@@ -1,9 +1,8 @@
 ﻿<html>
 <title>Video player - WMP</title>
 <meta charset="utf-8"/>
-<style type='text/css'>html, body { border-style: none; } </style><body>
-<h1></h1>
-
-<embed id='MediaPlayer' type='application/x-mplayer2'pluginspage='http://microsoft.com/windows/mediaplayer/en/download/'showcontrols='true' showpositioncontrols='true' showstatusbar='tue' showgotobar='true'src='%VideoUrl%' autostart='true' style='width: 100%; height: 100%;' />
+<style type='text/css'>html, body { border-style: none; } </style>
+<body>
+<embed id='MediaPlayer' type='application/x-mplayer2' pluginspage='http://microsoft.com/windows/mediaplayer/en/download/' showcontrols='true' showpositioncontrols='true' showstatusbar='tue' showgotobar='true' src='%VideoUrl%' autostart='true' style='width: 100%; height: 100%;' />
 </body>
 </html>

--- a/html/rovp-embedwm.htm
+++ b/html/rovp-embedwm.htm
@@ -1,0 +1,9 @@
+﻿<html>
+<title>Video player - WMP</title>
+<meta charset="utf-8"/>
+<style type='text/css'>html, body { border-style: none; } </style><body>
+<h1></h1>
+
+<embed id='MediaPlayer' type='application/x-mplayer2'pluginspage='http://microsoft.com/windows/mediaplayer/en/download/'showcontrols='true' showpositioncontrols='true' showstatusbar='tue' showgotobar='true'src='%VideoUrl%' autostart='true' style='width: 100%; height: 100%;' />
+</body>
+</html>

--- a/html/rovp-html5.htm
+++ b/html/rovp-html5.htm
@@ -1,9 +1,8 @@
 ﻿<html>
 <title>Video player - HTML5</title>
 <meta charset="utf-8"/>
-<style type='text/css'>html, body { border-style: none; } </style><body>
-<h1></h1>
-
+<style type='text/css'>html, body { border-style: none; } </style>
+<body>
 <center><video id='MediaPlayer' src='%VideoUrl%' controls='yes' autoplay='yes' style='width: 100%; height: 100%;'>Try another player type, as HTML5 is not supported.</video></center>
 </body>
 </html>

--- a/html/rovp-html5.htm
+++ b/html/rovp-html5.htm
@@ -1,8 +1,40 @@
 ﻿<html>
+<head>
 <title>Video player - HTML5</title>
 <meta charset="utf-8"/>
 <style type='text/css'>html, body { border-style: none; } </style>
+</head>
 <body>
-<center><video id='MediaPlayer' src='%VideoUrl%' controls='yes' autoplay='yes' style='width: 100%; height: 100%;'>Try another player type, as HTML5 is not supported.</video></center>
+<center><video id='MediaPlayer' src='%VideoUrl%' controls='yes' autoplay='yes' style='width: 70%;'>Try another player type, as HTML5 is not supported.</video></center>
+<center id="InfoBar"></center>
+
+<script>
+var getJSON = function(url, callback) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', url, true);
+    xhr.responseType = 'json';
+    xhr.onload = function() {
+      var status = xhr.status;
+      if (status === 200) {
+        callback(null, xhr.response);
+      } else {
+        callback(status, xhr.response);
+      }
+    };
+    xhr.send();
+   document.getElementById('InfoBar').innerHTML = '<p>Loading description...</p>';
+};
+
+getJSON('%JsonUrl%',
+function(err, data) {
+  document.getElementById('InfoBar').innerHTML = '';
+  if (err !== null) {
+    document.getElementById('InfoBar').innerHTML = '<p>No details: ' + err + '</p>';
+  } else {
+    document.getElementById('InfoBar').innerHTML = '<h2>' + data.fulltitle + '</h2>';
+    document.getElementById('InfoBar').innerHTML += '<p>Uploaded on ' + data.upload_date + ' by ' + data.uploader + '</p>';
+  }
+});
+</script>
 </body>
 </html>

--- a/html/rovp-html5.htm
+++ b/html/rovp-html5.htm
@@ -1,0 +1,9 @@
+﻿<html>
+<title>Video player - HTML5</title>
+<meta charset="utf-8"/>
+<style type='text/css'>html, body { border-style: none; } </style><body>
+<h1></h1>
+
+<center><video id='MediaPlayer' src='%VideoUrl%' controls='yes' autoplay='yes' style='width: 100%; height: 100%;'>Try another player type, as HTML5 is not supported.</video></center>
+</body>
+</html>

--- a/html/rovp-intro.htm
+++ b/html/rovp-intro.htm
@@ -1,0 +1,9 @@
+﻿<html>
+<title>Video player - INTRO</title>
+<meta charset="utf-8"/>
+<style type='text/css'>html, body { border-style: none; } </style><body>
+<h1></h1>
+
+<p align='center'><big>Use the toolbar above to watch a video.</big></p><noscript><p align='center'>If you have troubles with playback, read help page (&quot;?&quot; at the top).</p></noscript>
+</body>
+</html>

--- a/html/rovp-intro.htm
+++ b/html/rovp-intro.htm
@@ -1,9 +1,9 @@
 ﻿<html>
 <title>Video player - INTRO</title>
 <meta charset="utf-8"/>
-<style type='text/css'>html, body { border-style: none; } </style><body>
-<h1></h1>
-
-<p align='center'><big>Use the toolbar above to watch a video.</big></p><noscript><p align='center'>If you have troubles with playback, read help page (&quot;?&quot; at the top).</p></noscript>
+<style type='text/css'>html, body { border-style: none; } </style>
+<body>
+<p align='center'><big>Use the toolbar above to watch a video.</big></p>
+<noscript><p align='center'>If you have troubles with playback, read help page (&quot;?&quot; at the top).</p></noscript>
 </body>
 </html>

--- a/html/rovp-objectns.htm
+++ b/html/rovp-objectns.htm
@@ -1,9 +1,8 @@
 ﻿<html>
 <title>Video player - NetShow ActiveX</title>
 <meta charset="utf-8"/>
-<style type='text/css'>html, body { border-style: none; } </style><body>
-<h1></h1>
-
-<center><object ID='MediaPlayer' style='width: 100%; height: 100%;' CLASSID='CLSID:2179C5D3-EBFF-11CF-B6FD-00AA00B4E220' codebase='http://www.microsoft.com/netshow/download/en/nsasfinf.cab#Version=2,0,0,912'standby='Loading Microsoft NetShow Player components...'><param name='FileName' value='%VideoUrl%'><param name='ControlType' value='2'><param name='EnableContextMenu' value='true'><param name='AnimationAtStart' value='true'><param name='TransparentAtStart' value='false'><param name='AutoStart' value='true'>This mode is working only with Microsoft Internet Explorer 3 (or newer) and NetShow Player 2.0.</object></center>
+<style type='text/css'>html, body { border-style: none; } </style>
+<body>
+<center><object ID='MediaPlayer' style='width: 100%; height: 100%;' CLASSID='CLSID:2179C5D3-EBFF-11CF-B6FD-00AA00B4E220' codebase='http://www.microsoft.com/netshow/download/en/nsasfinf.cab#Version=2,0,0,912' standby='Loading Microsoft NetShow Player components...'><param name='FileName' value='%VideoUrl%'><param name='ControlType' value='2'><param name='EnableContextMenu' value='true'><param name='AnimationAtStart' value='true'><param name='TransparentAtStart' value='false'><param name='AutoStart' value='true'>This mode is working only with Microsoft Internet Explorer 3 (or newer) and NetShow Player 2.0.</object></center>
 </body>
 </html>

--- a/html/rovp-objectns.htm
+++ b/html/rovp-objectns.htm
@@ -1,0 +1,9 @@
+﻿<html>
+<title>Video player - NetShow ActiveX</title>
+<meta charset="utf-8"/>
+<style type='text/css'>html, body { border-style: none; } </style><body>
+<h1></h1>
+
+<center><object ID='MediaPlayer' style='width: 100%; height: 100%;' CLASSID='CLSID:2179C5D3-EBFF-11CF-B6FD-00AA00B4E220' codebase='http://www.microsoft.com/netshow/download/en/nsasfinf.cab#Version=2,0,0,912'standby='Loading Microsoft NetShow Player components...'><param name='FileName' value='%VideoUrl%'><param name='ControlType' value='2'><param name='EnableContextMenu' value='true'><param name='AnimationAtStart' value='true'><param name='TransparentAtStart' value='false'><param name='AutoStart' value='true'>This mode is working only with Microsoft Internet Explorer 3 (or newer) and NetShow Player 2.0.</object></center>
+</body>
+</html>

--- a/html/rovp-objectwm.htm
+++ b/html/rovp-objectwm.htm
@@ -1,9 +1,8 @@
 ﻿<html>
 <title>Video player - WMP ActiveX</title>
 <meta charset="utf-8"/>
-<style type='text/css'>html, body { border-style: none; } </style><body>
-<h1></h1>
-
-<center><object ID='MediaPlayer' style='width: 100%; height: 100%;' CLASSID='CLSID:6BF52A52-394A-11d3-B153-00C04F79FAA6' codebase='http://activex.microsoft.com/activex/controls/mplayer/en/nsmp2inf.cab#Version=6,4,7,1112'standby='Loading Microsoft Windows Media Player components...'><param name='URL' value='%VideoUrl%'><param name='ShowControls' value='true'><param name='ShowDisplay' value='true'><param name='ShowStatusBar' value='true'><param name='ShowPositionControls' value='true'><param name='ShowGoToBar' value='true'><param name='Controls' value='true'><param name='AutoSize' value='true'><param name='AutoStart' value='true'>Try another player type, as Windows Media Player Control 7.0 (or newer) is unavailable.</object></center>
+<style type='text/css'>html, body { border-style: none; } </style>
+<body>
+<center><object ID='MediaPlayer' style='width: 100%; height: 100%;' CLASSID='CLSID:6BF52A52-394A-11d3-B153-00C04F79FAA6' codebase='http://activex.microsoft.com/activex/controls/mplayer/en/nsmp2inf.cab#Version=6,4,7,1112' standby='Loading Microsoft Windows Media Player components...'><param name='URL' value='%VideoUrl%'><param name='ShowControls' value='true'><param name='ShowDisplay' value='true'><param name='ShowStatusBar' value='true'><param name='ShowPositionControls' value='true'><param name='ShowGoToBar' value='true'><param name='Controls' value='true'><param name='AutoSize' value='true'><param name='AutoStart' value='true'>Try another player type, as Windows Media Player Control 7.0 (or newer) is unavailable.</object></center>
 </body>
 </html>

--- a/html/rovp-objectwm.htm
+++ b/html/rovp-objectwm.htm
@@ -1,0 +1,9 @@
+﻿<html>
+<title>Video player - WMP ActiveX</title>
+<meta charset="utf-8"/>
+<style type='text/css'>html, body { border-style: none; } </style><body>
+<h1></h1>
+
+<center><object ID='MediaPlayer' style='width: 100%; height: 100%;' CLASSID='CLSID:6BF52A52-394A-11d3-B153-00C04F79FAA6' codebase='http://activex.microsoft.com/activex/controls/mplayer/en/nsmp2inf.cab#Version=6,4,7,1112'standby='Loading Microsoft Windows Media Player components...'><param name='URL' value='%VideoUrl%'><param name='ShowControls' value='true'><param name='ShowDisplay' value='true'><param name='ShowStatusBar' value='true'><param name='ShowPositionControls' value='true'><param name='ShowGoToBar' value='true'><param name='Controls' value='true'><param name='AutoSize' value='true'><param name='AutoStart' value='true'>Try another player type, as Windows Media Player Control 7.0 (or newer) is unavailable.</object></center>
+</body>
+</html>

--- a/html/rovp-splash.htm
+++ b/html/rovp-splash.htm
@@ -1,0 +1,34 @@
+﻿<html>
+<meta http-equiv="Refresh"
+content="5;url=/rovp.htm">
+<title>Retro online video player</title>
+<meta charset="utf-8"/>
+<style type='text/css'>h1, h2, h3, h4
+{
+font-family: sans-serif;
+}
+html
+{
+font-family: Cambria, sans-serif;
+}
+body
+{
+margin:4em auto;
+max-width: 52em;
+min-width: 13em;
+padding: 3em;
+}
+li
+{
+margin: 0px;
+}
+ul
+{
+list-style: square;
+}
+</style><style type='text/css'>html, body { border-style: none; } </style><body>
+<h1></h1>
+
+<div style="background-color: black; color: white; padding: 3em;"><p align="center"><a href="/rovp.htm"><img src="/rovp.gif" alt="Click here to open Retro Online Video Player." border="0"></a><br><h1 align="center">Retro Online Video Player</h1></p></div>
+</body>
+</html>

--- a/html/rovp-splash.htm
+++ b/html/rovp-splash.htm
@@ -26,9 +26,8 @@ ul
 {
 list-style: square;
 }
-</style><style type='text/css'>html, body { border-style: none; } </style><body>
-<h1></h1>
-
+</style><style type='text/css'>html, body { border-style: none; } </style>
+<body>
 <div style="background-color: black; color: white; padding: 3em;"><p align="center"><a href="/rovp.htm"><img src="/rovp.gif" alt="Click here to open Retro Online Video Player." border="0"></a><br><h1 align="center">Retro Online Video Player</h1></p></div>
 </body>
 </html>

--- a/webone.conf
+++ b/webone.conf
@@ -770,6 +770,10 @@ AddHeader=User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:140.0) Gecko/20
 [Edit:^http://play.google.com/log]
 AddRedirect=about:blank
 
+; Yandex outdated browser detection JS fix
+[Edit:^http://yastatic.net/browser-updater]
+AddRedirect=about:blank
+
 
 ; Firefox 3.5-16.0 CSS3 patches
 [Edit]

--- a/webone.conf
+++ b/webone.conf
@@ -21,6 +21,7 @@
 ; ValidateCertificates=Break network operations when the remote TLS certificate is bad
 ; MultipleHttp2Connections=Allow multiple HTTP/2 connections to servers
 ; RemoteHttpVersion=Version of HTTP(S) protocol, used to communicate with servers (min/max/exact)
+; ConnectionTimeout=Timeout to wait before the remote connection establishing times out (secs)
 ; UpperProxy=Another proxy server, used by WebOne to connect to Internet (optional)
 ; UserAgent=Override user-agent string to fetch uncut content
 ; AllowHttpCompression=Uncomment & disable to fix work of WSUS or LegacyUpdate (but proxy will slow)
@@ -47,6 +48,7 @@ EnableManualConverting=yes
 ValidateCertificates=yes
 MultipleHttp2Connections=yes
 ;RemoteHttpVersion=>1.1
+ConnectionTimeout=30
 ;UpperProxy=http://corporateproxyserver:80/
 ;UpperProxy=no
 UserAgent=%Original% WebOne/%WOVer%

--- a/webone.conf
+++ b/webone.conf
@@ -478,6 +478,25 @@ AddRedirect=http://web.archive.org/web/20040803152319/http://www.microsoft.com/r
 [Edit:^http://services.msn.com/svcs/mms/([a-zA-Z0-9]*)]
 AddRedirect=http://web.archive.org/web/2004/http://services.msn.com/svcs/mms/$1.asp
 
+; Windows Live Toolbar
+[Edit:^http://login.live.com/login.srf\?id=]
+AddRedirect=https://web.archive.org/web/20110427073719id_/http://toolbar.live.com/signin.htm
+
+[Edit:^http://toolbar.live.com/]
+AddRedirect=http://web.archive.org/web/2012/%URL%
+
+[Edit:^http://help.live.com/]
+AddRedirect=http://web.archive.org/web/2012/%URL%
+
+[Edit:^http://home.live.com/]
+AddRedirect=http://web.archive.org/web/2012/%URL%
+
+[Edit:^http://toolbar.msn.com/static/toolbar/ru-ru/manifest.cfg]
+AddRedirect=http://web.archive.org/web/20040213021205/http://toolbar.msn.com:80/static/toolbar/en-us/manifest.cfg
+
+[Edit:^http://toolbar.msn.com/]
+AddRedirect=http://web.archive.org/web/2003/%URL%
+
 ; Microsoft - common
 [Edit:^http://go.microsoft.com/]
 AddRedirect=http://web.archive.org/web/2005/%URL%


### PR DESCRIPTION
Changelog:
* Fixed `Unsuccessful Web Archive request: Bad Request` after recent Internet Archive update.
* Fixed Firefox 2.0 and Linux problem (#206). 
* Improved work of `RemoteHttpVersion` configuration option (no longer need to use `=` to specify exact version).
* Added fix for "your browser is out of date" on websites with Yandex browser check script.
* Added partial MSN Toolbar (Windows Live Toolbar) buttons support.
* Added Windows XP .NET Passport Wizard support via Escargot.
* Added detailed error page for rare "Loop requests are probhited" error with troubleshooting help.
* Added ability to specify connection establishing timeout via `ConnectionTimeout` option. By default it is now 30 sec, previously was 100 sec. But in some cases, the error message still may say "The request was canceled due to Timeout of 100 seconds elapsing". It's hardcoded into .NET Runtime, not a WebOne error message.
* Added displaying of video name in ROVP in HTML5 mode.
* Minor cleanup in ROVP pages HTML code, and they are now stored as HTML content files.